### PR TITLE
Bugfix: Wrong ArtemisWebView height when the connection speed is slow

### DIFF
--- a/Sources/DesignLibrary/ArtemisWebView.swift
+++ b/Sources/DesignLibrary/ArtemisWebView.swift
@@ -31,11 +31,14 @@ public struct ArtemisWebView: UIViewRepresentable {
     }
 
     public func makeUIView(context: Context) -> WKWebView {
+        // configure click event listener
         let config = WKWebViewConfiguration()
-        let source = "document.addEventListener('click', function(){ window.webkit.messageHandlers.iosListener.postMessage('click clack!'); })"
+        let source = "document.addEventListener('click', function(){ window.webkit.messageHandlers.iosListener.postMessage(''); })"
         let script = WKUserScript(source: source, injectionTime: .atDocumentEnd, forMainFrameOnly: false)
         config.userContentController.addUserScript(script)
         config.userContentController.add(context.coordinator, name: "iosListener")
+
+        // set up WKWebView
         let webView = WKWebView(frame: UIScreen.main.bounds, configuration: config)
         webView.scrollView.isScrollEnabled = isScrollEnabled
         webView.scrollView.showsHorizontalScrollIndicator = false
@@ -109,10 +112,11 @@ public struct ArtemisWebView: UIViewRepresentable {
         ///    we don't have a reliable way of checking when this loading process is really finished
         ///   - sampleInterval: the time interval between samples
         private func determineHeight(for webView: WKWebView, maxSampleCount: Int = 5, sampleInterval: TimeInterval = 1.0) {
-            timer?.invalidate()
+            timer?.invalidate() // because timer will be reused
 
             var currentSampleNumber = 0
 
+            // reuse the timer to set the height
             timer = Timer.scheduledTimer(withTimeInterval: sampleInterval, repeats: true) { [weak self] timer in
                 if currentSampleNumber == maxSampleCount {
                     timer.invalidate()
@@ -130,7 +134,6 @@ public struct ArtemisWebView: UIViewRepresentable {
         }
 
         public func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
-            print("message: \(message.body)")
             setParentHeight()
             // and whatever other actions you want to take
         }


### PR DESCRIPTION
I've noticed that the webview can't set it's height property correctly when the loading takes too long (more than 2 seconds). This affects users having slow connection speeds.

What I did:
- Added a timer that does the following:
  - Starts firing after the `webView(..didFinish navigation: )` is called
  - Checks every 0.5 seconds for `document.readyState` to be set
  - If set, it starts sampling the `document.body.scrollHeight` value. The sampling occurs 5 times with an interval of 1 seconds. 
 
This makes the webview start displaying content as it arrives, expanding its height

----
@sven0311  I noticed your latest commit also addresses this issue with clicks and preserved your implementation as well. With this PR both timer-based and click-based height adjustments should work fine. 🙂 