### PR TITLE
`Endpoint Change`: Replace Result with ParticipationResultDTO in CourseForDashboard

### DIFF
--- a/Sources/SharedModels/CourseForDashboard.swift
+++ b/Sources/SharedModels/CourseForDashboard.swift
@@ -1,6 +1,6 @@
 //
 //  File.swift
-//  
+//
 //
 //  Created by Sven Andabaka on 25.04.23.
 //
@@ -15,11 +15,17 @@ public struct CourseForDashboard: Codable {
     public var modelingScores: CourseScore?
     public var fileUploadScores: CourseScore?
     public var quizScores: CourseScore?
-    public var participationResults: [Result]?
+    public var participationResults: [ParticipationResultDTO]?
 }
 
 extension CourseForDashboard: Identifiable {
     public var id: Int {
         course.id
     }
+}
+
+public struct ParticipationResultDTO: Codable {
+    public var score: Double?
+    public var rated: Bool?
+    public var participationId: Int?
 }


### PR DESCRIPTION
Changes:
- Create a new DTO struct called `ParticipationResultDTO` 
- Change the type of `participationResults` from `Result` to `ParticipationResultDTO` in `CourseForDashboard` model. 

This is required because of the changes introduced in this Artemis PR: https://github.com/ls1intum/Artemis/pull/6984