### PR TITLE
`Modeling Exercises`: Add optional model and explanationText fields to ModelingSubmission

### DIFF
--- a/Sources/SharedModels/Exercise/Submission/ModelingSubmission.swift
+++ b/Sources/SharedModels/Exercise/Submission/ModelingSubmission.swift
@@ -19,4 +19,7 @@ public struct ModelingSubmission: BaseSubmission {
     public var durationInMinutes: Double?
     public var results: [Result]?
     public var participation: Participation?
+
+    public var model: String?
+    public var explanationText: String?
 }


### PR DESCRIPTION
This PR adds 2 optional fields to ModelingSubmissions:
- model
- explanationText

This change is required because Themis now supports modeling exercises.