### PR TITLE
Hashable conformance adjustments for the Exercise model

### DIFF
--- a/Sources/SharedModels/Exercise/BaseExercise.swift
+++ b/Sources/SharedModels/Exercise/BaseExercise.swift
@@ -255,9 +255,27 @@ private struct CategoryImpl: Codable {
 extension Exercise: Hashable {
     public static func == (lhs: Exercise, rhs: Exercise) -> Bool {
         lhs.id == rhs.id
+        && lhs.baseExercise.title == rhs.baseExercise.title
+        && lhs.baseExercise.dueDate == rhs.baseExercise.dueDate
+        && lhs.baseExercise.releaseDate == rhs.baseExercise.releaseDate
+        && lhs.baseExercise.assessmentDueDate == rhs.baseExercise.assessmentDueDate
+        && lhs.baseExercise.numberOfSubmissions == rhs.baseExercise.numberOfSubmissions
+        && lhs.baseExercise.numberOfOpenComplaints == rhs.baseExercise.numberOfOpenComplaints
+        && lhs.baseExercise.totalNumberOfAssessments == rhs.baseExercise.totalNumberOfAssessments
+        && lhs.baseExercise.numberOfOpenMoreFeedbackRequests == rhs.baseExercise.numberOfOpenMoreFeedbackRequests
+        && lhs.baseExercise.numberOfAssessmentsOfCorrectionRounds == rhs.baseExercise.numberOfAssessmentsOfCorrectionRounds
     }
 
     public func hash(into hasher: inout Hasher) {
         hasher.combine(id)
+        hasher.combine(baseExercise.title)
+        hasher.combine(baseExercise.dueDate)
+        hasher.combine(baseExercise.releaseDate)
+        hasher.combine(baseExercise.assessmentDueDate)
+        hasher.combine(baseExercise.numberOfSubmissions)
+        hasher.combine(baseExercise.numberOfOpenComplaints)
+        hasher.combine(baseExercise.totalNumberOfAssessments)
+        hasher.combine(baseExercise.numberOfOpenMoreFeedbackRequests)
+        hasher.combine(baseExercise.numberOfAssessmentsOfCorrectionRounds)
     }
 }

--- a/Sources/SharedModels/Exercise/Stats/DueDateStat.swift
+++ b/Sources/SharedModels/Exercise/Stats/DueDateStat.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct DueDateStat: Codable {
+public struct DueDateStat: Codable, Hashable {
     public let inTime: Int
     public let late: Int
 }


### PR DESCRIPTION
Modified the `hash(into:)` and `==` functions of `Exercise` to also consider some date and assessment-related fields.

This is useful for cases when, for example, an array of exercises are passed to a  `ForEach` element. Previously, `ForEach` differentiated elements based on `id`, and this led to issues where a change to an exercise deadline or title was not immediately reflected on the UI.