### PR TITLE
`Fix`: Starscream build issue

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -51,7 +51,8 @@ let package = Package(
         .package(url: "https://github.com/realm/SwiftLint.git", from: "0.51.0"),
         .package(url: "https://github.com/gonzalezreal/swift-markdown-ui", from: "2.0.0"),
         .package(url: "https://github.com/onevcat/Kingfisher.git", .upToNextMajor(from: "7.0.0")),
-        .package(url: "https://github.com/Romixery/SwiftStomp.git", .upToNextMajor(from: "1.0.4"))
+        .package(url: "https://github.com/Romixery/SwiftStomp.git", .upToNextMajor(from: "1.0.4")),
+        .package(url: "https://github.com/daltoniam/Starscream", exact: "4.0.4")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -52,6 +52,7 @@ let package = Package(
         .package(url: "https://github.com/gonzalezreal/swift-markdown-ui", from: "2.0.0"),
         .package(url: "https://github.com/onevcat/Kingfisher.git", .upToNextMajor(from: "7.0.0")),
         .package(url: "https://github.com/Romixery/SwiftStomp.git", .upToNextMajor(from: "1.0.4")),
+        // TODO: remove the dependency below once the WebSocketDelegate issue is fixed
         .package(url: "https://github.com/daltoniam/Starscream", exact: "4.0.4")
     ],
     targets: [


### PR DESCRIPTION
This PR fixes a build problem that originated from a dependency named Starscream. Starscream is not a direct dependency of ArtemisCore but a dependency of SwiftStomp, which is used for communication-related features in ArtemisCore. You can see a screenshot of the error below:

<img width="1440" alt="stomp error" src="https://github.com/ls1intum/artemis-ios-core-modules/assets/22798314/58a4794d-49ce-4804-a029-4cfe8a44ec6a">
