### PR TITLE
Revert Starscream dependency fix

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -52,8 +52,6 @@ let package = Package(
         .package(url: "https://github.com/gonzalezreal/swift-markdown-ui", from: "2.0.0"),
         .package(url: "https://github.com/onevcat/Kingfisher.git", .upToNextMajor(from: "7.0.0")),
         .package(url: "https://github.com/Romixery/SwiftStomp.git", .upToNextMajor(from: "1.0.4")),
-        // TODO: remove the dependency below once the WebSocketDelegate issue is fixed
-        .package(url: "https://github.com/daltoniam/Starscream", exact: "4.0.4")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
This PR reverts #15 since it did not produce the desired effect. When ArtemisCore is imported as a non-local dependency, Xcode still fetches the latest version of Starscream, ignoring the exact version specified in the `Package` file.