### PR TITLE
`Development`: Fix HTTP method

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ In Project Settings, on the tab "Package Dependencies", click "+" and add <https
 1. Add a dependency in Package.swift:
 ```swift
 dependencies: [
-    .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "3.5.0")),
+    .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "4.0.0")),
 ]
 ```
 

--- a/Sources/APIClient/HTTPMethod.swift
+++ b/Sources/APIClient/HTTPMethod.swift
@@ -11,11 +11,11 @@ public enum HTTPMethod: String, CustomStringConvertible {
     case connect
     case delete
     case get
-    case post
     case head
-    case put
     case options
-    case update
+    case patch
+    case post
+    case put
 
     public var description: String {
         return rawValue.uppercased()


### PR DESCRIPTION
`UPDATE` becomes `PATCH` because the former does not exist as a HTTP request method [[1](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/PATCH)]

Alternatively, we could use the newly released [Swift HTTP Types](https://github.com/ls1intum/artemis-ios-core-modules/pull/22#swift-http-types) library.