### PR TITLE
`Development`: Fix could not decode ProfileInfo's buildPlanURLTemplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ In Project Settings, on the tab "Package Dependencies", click "+" and add <https
 1. Add a dependency in Package.swift:
 ```swift
 dependencies: [
-    .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "6.0.0")),
+    .package(url: "https://github.com/ls1intum/artemis-ios-core-modules", .upToNextMajor(from: "7.0.0")),
 ]
 ```
 

--- a/Sources/ProfileInfo/Model/ProfileInfo.swift
+++ b/Sources/ProfileInfo/Model/ProfileInfo.swift
@@ -22,7 +22,7 @@ public struct ProfileInfo: Codable {
     public let externalCredentialProvider: String?
     public let externalPasswordResetLinkMap: [String: String]?
     public let useExternal: Bool
-    public let buildPlanURLTemplate: String
+    public let buildPlanURLTemplate: String?
     public let activeProfiles: [String]
 }
 


### PR DESCRIPTION
Some test servers use a local VC & CI setup, i.e.:

- artemis-test3.artemis.cit.tum.de
- artemis-test6.artemis.cit.tum.de

Previously, an iOS client could not log in to these test servers because of a decoding error:

```
"No value associated with key CodingKeys(string Value: \"buildPlanURLTemplate\", intValue: nil) (\"buildPlanURLTemplate\")."
```