### PR TITLE
`Exercise Stats`: Add number of assessments of correction rounds

### DIFF
--- a/Sources/SharedModels/Exercise/Stats/ExerciseStatsForAssessmentDashboard.swift
+++ b/Sources/SharedModels/Exercise/Stats/ExerciseStatsForAssessmentDashboard.swift
@@ -13,6 +13,7 @@ public struct ExerciseStatsForAssessmentDashboard: Codable {
     public let numberOfStudent: Int?
     public let numberOfSubmissions: DueDateStat?
     public let totalNumberOfAssessments: DueDateStat?
+    public let numberOfAssessmentsOfCorrectionRounds: [DueDateStat]?
     public let complaintsEnabled: Bool?
     public let feedbackRequestEnabled: Bool?
 }


### PR DESCRIPTION
This PR adds a new `numberOfAssessmentsOfCorrectionRounds` to `ExerciseStatsForAssessmentDashboard`. The change is required by Themis to show the assessment statistic for exercises in the second correction round of an exam.