### PR TITLE
`Buttons`: Add Custom Init for the Artemis Button Style

### DIFF
--- a/Sources/DesignLibrary/ArtemisButtonStyle.swift
+++ b/Sources/DesignLibrary/ArtemisButtonStyle.swift
@@ -26,7 +26,11 @@ public struct ArtemisButton: ButtonStyle {
         self.buttonPriority = priority
     }
 
-    // maybe add custom priority init
+    public init(buttonColor: Color, buttonTextColor: Color) {
+        self.buttonPriority = .custom
+        self.buttonColor = buttonColor
+        self.buttonTextColor = buttonTextColor
+    }
 
     public func makeBody(configuration: ButtonStyleConfiguration) -> some View {
         configuration.label


### PR DESCRIPTION
This PR adds a custom initializer for the Artemis Button Style to allow changing the color of the button.