### PR TITLE
`Modeling Exercises`: Add BPMN case to Shared Models

### DIFF
--- a/Sources/SharedModels/Exercise/ModelingExercise.swift
+++ b/Sources/SharedModels/Exercise/ModelingExercise.swift
@@ -64,4 +64,5 @@ public enum UMLDiagramType: String, Codable {
     case petriNet = "PetriNet"
     case syntaxTree = "SyntaxTree"
     case flowchart = "Flowchart"
+    case BPMN = "BPMN"
 }


### PR DESCRIPTION
This PR adds BPMN as a diagram type to the modeling exercise shared models. It fixes a bug that shows an error on the dashboard screen.