### PR TITLE
`Courses`: Add `numberOfLectures` helper attribute

### DIFF
--- a/Sources/SharedModels/Course/Course.swift
+++ b/Sources/SharedModels/Course/Course.swift
@@ -26,6 +26,9 @@ public struct Course: Codable, Identifiable {
     public var editorGroupName: String?
     public var teachingAssistantGroupName: String?
 
+    // helper attributes, if DTO does not contain complete data
+    public var numberOfLectures: Int?
+
     public init(id: Int, title: String? = "",
                 description: String? = "",
                 courseIcon: String? = nil,


### PR DESCRIPTION
`api/courses/for-dashboard` does not return `lectures` data, but `api/courses/\(courseId)/for-dashboard` does.

Add `numberOfLectures` to display it in the dashboard.

Ref.: [course.model.ts](https://github.com/ls1intum/Artemis/blob/4eb01fd95356dea74cc5b10b601d98fa69fab5d0/src/main/webapp/app/entities/course.model.ts)