### PR TITLE
`Communication` **Breaking**: Merge Messaging and Communication

### DIFF
--- a/Sources/SharedModels/Course/Course.swift
+++ b/Sources/SharedModels/Course/Course.swift
@@ -156,8 +156,4 @@ public enum CourseInformationSharingConfiguration: String, RawRepresentable, Cod
      * Only Communication is enabled VALUE = 2
      */
     case communicationOnly = "COMMUNICATION_ONLY"
-    /**
-     * Only Messaging is enabled VALUE = 3
-     */
-    case messagingOnly = "MESSAGING_ONLY"
 }


### PR DESCRIPTION
### Problem
With [this PR of Artemis](https://github.com/ls1intum/Artemis/pull/8801), Courses can choose the following options for messaging:
- Disabled (no communication)
- Communication only (only channels like announcement, organization …)
- Communication and messaging (channels as well as direct and group messages)

Messaging only will no longer exist.

### Solution
Therefore, we remove the `messagingOnly` option.