### PR TITLE
`Notifications`: Fix size of PushNotificationSetupView

### DIFF
--- a/Sources/PushNotifications/Views/PushNotificationSetupView.swift
+++ b/Sources/PushNotifications/Views/PushNotificationSetupView.swift
@@ -25,7 +25,9 @@ public struct PushNotificationSetupView: View {
             Image("notifications", bundle: .module)
                 .resizable()
                 .scaledToFit()
-                .frame(width: UIScreen.main.bounds.size.width * 0.8)
+                .containerRelativeFrame(.horizontal) { width, _ in
+                    width * 0.8
+                }
             Text(R.string.localizable.push_notification_settings_receive_label())
                 .bold()
             Text(R.string.localizable.push_notification_settings_receive_information())


### PR DESCRIPTION
### Problem
Currently, the image on `PushNotificationSetupView` is sized using `UIScreen.main.bounds.width * 0.8`. While this works on iPhone, it doesn't work on iPad. This view gets shown inside a sheet on the iPad, which is not full width. Therefore, the width that gets set is wider than the sheet itself, which leads to text being cut off (see screenshot).

### Solution
By using `containerRelativeFrame`, we can make the Image span a maximum of 80% of the available width, which is what the original code intended.

### Before vs After
<img src="https://github.com/ls1intum/artemis-ios-core-modules/assets/98647423/3e2fda00-3a3e-4341-8c69-ab1b652c5c3a" alt="Before" width="330">
<img src="https://github.com/ls1intum/artemis-ios-core-modules/assets/98647423/9a540c52-c234-4d30-81ea-b3e31f644eeb" alt="After" width="330">