### PR TITLE
`Exercises`: Add Rust programming language

### DIFF
--- a/Sources/SharedModels/Exercise/ProgrammingExercise.swift
+++ b/Sources/SharedModels/Exercise/ProgrammingExercise.swift
@@ -103,5 +103,6 @@ public enum ProgrammingLanguage: String, RawRepresentable, Codable {
     case assembler = "ASSEMBLER"
     case swift = "SWIFT"
     case ocaml = "OCAML"
+    case rust = "RUST"
     case empty = "EMPTY"
 }


### PR DESCRIPTION
With [Artemis#8802](https://github.com/ls1intum/Artemis/pull/8802), there will be an option to create programming exercises with Rust as the programming language. We need to support this as well to make sure decoding server responses doesn't fail.