### PR TITLE
`Exercises`: Prevent decoding failures for future new programming language constants

### DIFF
--- a/Sources/SharedModels/Exercise/ProgrammingExercise.swift
+++ b/Sources/SharedModels/Exercise/ProgrammingExercise.swift
@@ -92,7 +92,7 @@ public extension ProgrammingExercise {
     )
 }
 
-public enum ProgrammingLanguage: String, RawRepresentable, Codable {
+public enum ProgrammingLanguage: String, RawRepresentable, Codable, CaseIterable {
     case java = "JAVA"
     case javascript = "JAVASCRIPT"
     case python = "PYTHON"
@@ -105,4 +105,10 @@ public enum ProgrammingLanguage: String, RawRepresentable, Codable {
     case ocaml = "OCAML"
     case rust = "RUST"
     case empty = "EMPTY"
+    case unknown
+
+    public init(from decoder: Decoder) throws {
+        let string = try decoder.singleValueContainer().decode(String.self)
+        self = Self.allCases.first { $0.rawValue == string } ?? .unknown
+    }
 }


### PR DESCRIPTION
### Problem
Currently, whenever support for a new Programming Language is added to Artemis, the iOS app will fail to load the entire dashboard or any course if an exercise with that new language exists. Therefore, no course can be accessed at all until support for the new language has been added. The reason for this is that we cannot decode any server response that contains an exercise with unknown programming language.

### Proposed Solution
By adding an `unknown` case to our Programming Languages, we can ensure that this issue does not occur when new languages are added in the future. The iOS Apps continue to function with existing languages.

### Examples
- "JAVA" decodes to `.java`
- "C" decodes to `.c`
- "PYTHON" decodes to `.python`
- "JULIA" decodes to `.unknown` (we don't have an enum case for it)