### PR TITLE
`Communication`: Use megaphone instead of bell for announcement channel

### DIFF
--- a/Sources/SharedModels/Conversation/Channel.swift
+++ b/Sources/SharedModels/Conversation/Channel.swift
@@ -47,7 +47,7 @@ public struct Channel: BaseConversation {
             return Image(systemName: "archivebox.fill")
         }
         if isAnnouncementChannel ?? false {
-            return Image(systemName: "bell.fill")
+            return Image(systemName: "megaphone.fill")
         }
         if isPublic ?? false {
             return Image(systemName: "number")


### PR DESCRIPTION
The web app uses a megaphone icon for announcement channels, with this PR we ensure consistency between it and the iOS app.