### PR TITLE
`Notifications`: Prevent dismissing PushNotificationSettings with unsaved changes

### DIFF
--- a/Sources/PushNotifications/Views/PushNotificationSettingsView.swift
+++ b/Sources/PushNotifications/Views/PushNotificationSettingsView.swift
@@ -56,6 +56,7 @@ public struct PushNotificationSettingsView: View {
                 PushNotificationSetupView(shouldCloseOnSkip: true)
             }
         }
+        .interactiveDismissDisabled(!viewModel.isSaveDisabled)
     }
 }
 


### PR DESCRIPTION
### Problem
Currently, the user can edit some of the Push Notification Settings and then (maybe on accident) dismiss the sheet by swiping down. Changes are not saved in this case, which may be confusing since the toggle has already switched state.

### Proposed solution
Swiping down to dismiss the sheet is only available as long as the user has not changed any notification settings. As soon as a change has been made that could be saved, dismissing the sheet by swiping is no longer possible. Users need to take explicit action by either pressing on Cancel or Save to make their intent clear.