### PR TITLE
`Exercises`: Fix decoding failure for Exercise Details

### DIFF
--- a/Sources/SharedModels/Exercise/ExerciseDetailsDTO.swift
+++ b/Sources/SharedModels/Exercise/ExerciseDetailsDTO.swift
@@ -1,0 +1,12 @@
+//
+//  ExerciseDetailsDTO.swift
+//
+//
+//  Created by Anian Schleyer on 06.07.24.
+//
+
+import Foundation
+
+public struct ExerciseDetailsDTO: Codable {
+    public let exercise: Exercise
+}

--- a/Sources/SharedServices/ExerciseService/ExerciseServiceImpl.swift
+++ b/Sources/SharedServices/ExerciseService/ExerciseServiceImpl.swift
@@ -16,7 +16,7 @@ public class ExerciseServiceImpl: ExerciseService {
 
     // MARK: - Get Exercise
     struct GetExerciseRequest: APIRequest {
-        typealias Response = Exercise
+        typealias Response = ExerciseDetailsDTO
 
         var exerciseId: Int
 
@@ -34,7 +34,7 @@ public class ExerciseServiceImpl: ExerciseService {
 
         switch result {
         case .success((let response, _)):
-            return .done(response: response)
+            return .done(response: response.exercise)
         case .failure(let error):
             return .failure(error: UserFacingError(error: error))
         }


### PR DESCRIPTION
Due to changes in [Artemis#8712](https://github.com/ls1intum/Artemis/pull/8712), decoding responses to `/api/exercises/:id/details` fail because the structure of the response has changed. We get a new ExerciseDetailsDTO instead of an Exercise.

This leads to decoding failures in the app when opening notifications or pulling to refresh on an exercise.

<img src="https://github.com/ls1intum/artemis-ios-core-modules/assets/98647423/480599fa-7f56-4340-87ed-103ff3c6f841" alt="Decoding error" width="300">

