### PR TITLE
`Communication`: Label for user role

### DIFF
--- a/Sources/DesignLibrary/Chip.swift
+++ b/Sources/DesignLibrary/Chip.swift
@@ -11,12 +11,21 @@ public struct Chip: View {
 
     var text: String
     var backgroundColor: Color
-    var padding: CGFloat
+    var horizontalPadding: CGFloat
+    var verticalPadding: CGFloat
 
     public init(text: String, backgroundColor: Color, padding: CGFloat = .m) {
         self.text = text
         self.backgroundColor = backgroundColor
-        self.padding = padding
+        self.horizontalPadding = padding
+        self.verticalPadding = padding
+    }
+
+    public init(text: String, backgroundColor: Color, horizontalPadding: CGFloat, verticalPadding: CGFloat) {
+        self.text = text
+        self.backgroundColor = backgroundColor
+        self.horizontalPadding = horizontalPadding
+        self.verticalPadding = verticalPadding
     }
 
     public var body: some View {
@@ -24,7 +33,8 @@ public struct Chip: View {
             .bold()
             .lineLimit(1)
             .foregroundColor(.white)
-            .padding(padding)
+            .padding(.horizontal, horizontalPadding)
+            .padding(.vertical, verticalPadding)
             .background(backgroundColor)
             .cornerRadius(8)
     }

--- a/Sources/SharedModels/Conversation/Message/AnswerMessage.swift
+++ b/Sources/SharedModels/Conversation/Message/AnswerMessage.swift
@@ -14,7 +14,7 @@ public struct AnswerMessage: BaseMessage {
     public var updatedDate: Date?
     public var content: String?
     public var tokenizedContent: String?
-    public var authorRoleTransient: UserRole?
+    public var authorRole: UserRole?
 
     public var resolvesPost: Bool?
     public var reactions: [Reaction]?

--- a/Sources/SharedModels/Conversation/Message/BaseMessage.swift
+++ b/Sources/SharedModels/Conversation/Message/BaseMessage.swift
@@ -15,7 +15,7 @@ public protocol BaseMessage: Codable {
     var updatedDate: Date? { get }
     var content: String? { get }
     var tokenizedContent: String? { get }
-    var authorRoleTransient: UserRole? { get }
+    var authorRole: UserRole? { get }
     var reactions: [Reaction]? { get }
 }
 

--- a/Sources/SharedModels/Conversation/Message/Message.swift
+++ b/Sources/SharedModels/Conversation/Message/Message.swift
@@ -8,7 +8,7 @@ public struct Message: BaseMessage {
     public var updatedDate: Date?
     public var content: String?
     public var tokenizedContent: String?
-    public var authorRoleTransient: UserRole?
+    public var authorRole: UserRole?
 
     public var title: String?
     public var visibleForStudents: Bool?

--- a/Sources/SharedModels/User/UserRole.swift
+++ b/Sources/SharedModels/User/UserRole.swift
@@ -6,9 +6,25 @@
 //
 
 import Foundation
+import SwiftUI
 
 public enum UserRole: String, RawRepresentable, Codable {
     case instructor = "INSTRUCTOR"
     case tutor = "TUTOR"
     case user = "USER"
+
+    public var displayName: String {
+        rawValue.capitalized
+    }
+
+    public var badgeColor: Color {
+        switch self {
+        case .instructor:
+            return .init(red: 204, green: 0, blue: 0)
+        case .tutor:
+            return .init(red: 253, green: 126, blue: 20)
+        case .user:
+            return .init(red: 23, green: 162, blue: 184)
+        }
+    }
 }

--- a/Sources/SharedModels/User/UserRole.swift
+++ b/Sources/SharedModels/User/UserRole.swift
@@ -20,11 +20,11 @@ public enum UserRole: String, RawRepresentable, Codable {
     public var badgeColor: Color {
         switch self {
         case .instructor:
-            return .init(red: 204, green: 0, blue: 0)
+            return .init(red: 204/255, green: 0, blue: 0)
         case .tutor:
-            return .init(red: 253, green: 126, blue: 20)
+            return .init(red: 253/255, green: 126/255, blue: 20/255)
         case .user:
-            return .init(red: 23, green: 162, blue: 184)
+            return .init(red: 23/255, green: 162/255, blue: 184/255)
         }
     }
 }

--- a/Sources/SharedModels/User/UserRole.swift
+++ b/Sources/SharedModels/User/UserRole.swift
@@ -14,17 +14,21 @@ public enum UserRole: String, RawRepresentable, Codable {
     case user = "USER"
 
     public var displayName: String {
-        rawValue.capitalized
+        if self == .user {
+            return "Student"
+        } else {
+            return rawValue.capitalized
+        }
     }
 
     public var badgeColor: Color {
         switch self {
         case .instructor:
-            return .init(red: 204/255, green: 0, blue: 0)
+            return .init(red: 204 / 255, green: 0, blue: 0)
         case .tutor:
-            return .init(red: 253/255, green: 126/255, blue: 20/255)
+            return .init(red: 253 / 255, green: 126 / 255, blue: 20 / 255)
         case .user:
-            return .init(red: 23/255, green: 162/255, blue: 184/255)
+            return .init(red: 23 / 255, green: 162 / 255, blue: 184 / 255)
         }
     }
 }


### PR DESCRIPTION
- Make `UserRole` more usable for displaying in Conversation View
- Rename `authorRoleTransient` to `authorRole`
- Make Padding of `Chip` more customizable