### PR TITLE
`Communication`: Add missing icon for DMs

### DIFF
--- a/Sources/SharedModels/Conversation/OneToOneChat.swift
+++ b/Sources/SharedModels/Conversation/OneToOneChat.swift
@@ -31,7 +31,7 @@ public struct OneToOneChat: BaseConversation {
     }
 
     public var icon: Image? {
-        nil
+        Image(systemName: "lock.fill")
     }
 }
 


### PR DESCRIPTION
### Problem
Direct messages (one to one chats) currently don't have an icon.