### PR TITLE
`Notifications`: Fix incorrect targets

### DIFF
--- a/Sources/PushNotifications/Models/PushNotification.swift
+++ b/Sources/PushNotifications/Models/PushNotification.swift
@@ -242,11 +242,11 @@ public enum PushNotificationType: String, Codable {
         case .newReplyForExamPost:
             return nil
         case .newReplyForExercisePost:
-            guard notificationPlaceholders.count > 8 else { return nil }
+            guard notificationPlaceholders.count > 7 else { return nil }
             return R.string.localizable.artemisAppGroupNotificationTextNewReplyForExercisePost(notificationPlaceholders[0],
+                                                                                               notificationPlaceholders[3],
                                                                                                notificationPlaceholders[4],
-                                                                                               notificationPlaceholders[5],
-                                                                                               notificationPlaceholders[8])
+                                                                                               notificationPlaceholders[7])
         case .newReplyForLecturePost:
             guard notificationPlaceholders.count > 8 else { return nil }
             return R.string.localizable.artemisAppGroupNotificationTextNewReplyForLecturePost(notificationPlaceholders[0],

--- a/Sources/PushNotifications/Models/PushNotification.swift
+++ b/Sources/PushNotifications/Models/PushNotification.swift
@@ -248,11 +248,11 @@ public enum PushNotificationType: String, Codable {
                                                                                                notificationPlaceholders[4],
                                                                                                notificationPlaceholders[7])
         case .newReplyForLecturePost:
-            guard notificationPlaceholders.count > 8 else { return nil }
+            guard notificationPlaceholders.count > 7 else { return nil }
             return R.string.localizable.artemisAppGroupNotificationTextNewReplyForLecturePost(notificationPlaceholders[0],
+                                                                                              notificationPlaceholders[3],
                                                                                               notificationPlaceholders[4],
-                                                                                              notificationPlaceholders[5],
-                                                                                              notificationPlaceholders[8])
+                                                                                              notificationPlaceholders[7])
         //
         case .newAnnouncementPost:
             guard notificationPlaceholders.count > 2 else { return nil }

--- a/Sources/PushNotifications/PushNotificationResponseHandler.swift
+++ b/Sources/PushNotifications/PushNotificationResponseHandler.swift
@@ -42,8 +42,8 @@ public class PushNotificationResponseHandler {
                 .conversationAddUserGroupChat,
                 .conversationRemoveUserChannel,
                 .conversationRemoveUserGroupChat:
-            guard let target = try? decoder.decode(NewLecturePostTarget.self, from: targetData) else { return nil }
-            return "courses/\(target.course)/communication?conversationId=\(target.id)"
+            guard let target = try? decoder.decode(ConversationTarget.self, from: targetData) else { return nil }
+            return "courses/\(target.course)/communication?conversationId=\(target.conversation)"
         default:
             guard let target = try? decoder.decode(GeneralTarget.self, from: targetData) else { return nil }
             return "courses/\(target.course)/\(target.entity)/\(target.id)"

--- a/Sources/PushNotifications/PushNotificationResponseHandler.swift
+++ b/Sources/PushNotifications/PushNotificationResponseHandler.swift
@@ -30,7 +30,7 @@ public class PushNotificationResponseHandler {
             return "courses/\(target.course)/quiz-exercises/\(target.id)/live"
         case .newReplyForCoursePost, .newCoursePost, .newAnnouncementPost:
             guard let target = try? decoder.decode(NewCoursePostTarget.self, from: targetData) else { return nil }
-            return "courses/\(target.course)/discussion?searchText=%23\(target.id)"
+            return "courses/\(target.course)/communication?conversationId=\(target.conversation)"
         case .newExercisePost, .newReplyForExercisePost:
             guard let target = try? decoder.decode(NewExercisePostTarget.self, from: targetData) else { return nil }
             return "courses/\(target.course)/exercises/\(target.exercise ?? target.exerciseId ?? 0)?postId=\(target.id)"
@@ -43,7 +43,7 @@ public class PushNotificationResponseHandler {
                 .conversationRemoveUserChannel,
                 .conversationRemoveUserGroupChat:
             guard let target = try? decoder.decode(NewLecturePostTarget.self, from: targetData) else { return nil }
-            return "courses/\(target.course)/messages?conversationId=\(target.id)"
+            return "courses/\(target.course)/communication?conversationId=\(target.id)"
         default:
             guard let target = try? decoder.decode(GeneralTarget.self, from: targetData) else { return nil }
             return "courses/\(target.course)/\(target.entity)/\(target.id)"
@@ -58,6 +58,7 @@ private struct QuizExerciseStartedTarget: Codable {
 
 private struct NewCoursePostTarget: Codable {
     let course: Int
+    let conversation: Int
     let id: Int
 }
 


### PR DESCRIPTION
newReplyForExercisePost and newReplyForLecturePost didn't work at all,
Create/Add/Remove channel did not use correct ConversationTarget