### PR TITLE
`Notifications`: Fix wrong content and targets for lecture/exercise posts

### DIFF
--- a/Sources/PushNotifications/Models/PushNotification.swift
+++ b/Sources/PushNotifications/Models/PushNotification.swift
@@ -265,15 +265,15 @@ public enum PushNotificationType: String, Codable {
         case .newExamPost:
             return nil
         case .newExercisePost:
-            guard notificationPlaceholders.count > 5 else { return nil }
+            guard notificationPlaceholders.count > 4 else { return nil }
             return R.string.localizable.artemisAppGroupNotificationTextNewExercisePost(notificationPlaceholders[0],
-                                                                                       notificationPlaceholders[2],
-                                                                                       notificationPlaceholders[5])
+                                                                                       notificationPlaceholders[1],
+                                                                                       notificationPlaceholders[4])
         case .newLecturePost:
-            guard notificationPlaceholders.count > 5 else { return nil }
+            guard notificationPlaceholders.count > 4 else { return nil }
             return R.string.localizable.artemisAppGroupNotificationTextNewLecturePost(notificationPlaceholders[0],
-                                                                                      notificationPlaceholders[2],
-                                                                                      notificationPlaceholders[5])
+                                                                                      notificationPlaceholders[1],
+                                                                                      notificationPlaceholders[4])
         //
         case .courseArchiveStarted:
             guard notificationPlaceholders.count > 0 else { return nil }

--- a/Sources/PushNotifications/PushNotificationResponseHandler.swift
+++ b/Sources/PushNotifications/PushNotificationResponseHandler.swift
@@ -28,15 +28,9 @@ public class PushNotificationResponseHandler {
         case .quizExerciseStarted:
             guard let target = try? decoder.decode(QuizExerciseStartedTarget.self, from: targetData) else { return nil }
             return "courses/\(target.course)/quiz-exercises/\(target.id)/live"
-        case .newReplyForCoursePost, .newCoursePost, .newAnnouncementPost:
-            guard let target = try? decoder.decode(NewCoursePostTarget.self, from: targetData) else { return nil }
+        case .newReplyForCoursePost, .newCoursePost, .newAnnouncementPost, .newExercisePost, .newReplyForExercisePost, .newLecturePost, .newReplyForLecturePost:
+            guard let target = try? decoder.decode(NewPostTarget.self, from: targetData) else { return nil }
             return "courses/\(target.course)/communication?conversationId=\(target.conversation)"
-        case .newExercisePost, .newReplyForExercisePost:
-            guard let target = try? decoder.decode(NewExercisePostTarget.self, from: targetData) else { return nil }
-            return "courses/\(target.course)/exercises/\(target.exercise ?? target.exerciseId ?? 0)?postId=\(target.id)"
-        case .newLecturePost, .newReplyForLecturePost:
-            guard let target = try? decoder.decode(NewLecturePostTarget.self, from: targetData) else { return nil }
-            return "courses/\(target.course)/lectures/\(target.lecture ?? target.lectureId ?? 0)?postId=\(target.id)"
         case .conversationCreateGroupChat,
                 .conversationAddUserChannel,
                 .conversationAddUserGroupChat,
@@ -56,24 +50,10 @@ private struct QuizExerciseStartedTarget: Codable {
     let id: Int
 }
 
-private struct NewCoursePostTarget: Codable {
+private struct NewPostTarget: Codable {
     let course: Int
     let conversation: Int
     let id: Int
-}
-
-private struct NewExercisePostTarget: Codable {
-    let id: Int
-    let course: Int
-    let exercise: Int?
-    let exerciseId: Int?
-}
-
-private struct NewLecturePostTarget: Codable {
-    let id: Int
-    let course: Int
-    let lecture: Int?
-    let lectureId: Int?
 }
 
 private struct ConversationTarget: Codable {


### PR DESCRIPTION
### Problem
Exercise and Lecture Post notifications show the wrong content. We fix this.
<img src="https://github.com/user-attachments/assets/41b6db5b-96d0-42ca-8a06-363858b4f1c5" width="300">

These and reply notifications then show a "This link is not supported by the app" error. We fix this as well.