### PR TITLE
`Notifications`: Add target for new DM Notifications

### DIFF
--- a/Sources/PushNotifications/PushNotificationResponseHandler.swift
+++ b/Sources/PushNotifications/PushNotificationResponseHandler.swift
@@ -35,7 +35,8 @@ public class PushNotificationResponseHandler {
                 .conversationAddUserChannel,
                 .conversationAddUserGroupChat,
                 .conversationRemoveUserChannel,
-                .conversationRemoveUserGroupChat:
+                .conversationRemoveUserGroupChat,
+                .conversationNewMessage:
             guard let target = try? decoder.decode(ConversationTarget.self, from: targetData) else { return nil }
             return "courses/\(target.course)/communication?conversationId=\(target.conversation)"
         default:


### PR DESCRIPTION
When a user receives a Notification about a new DM, the target is missing so that he/she ends up at the error saying this link is not supported.