### PR TITLE
`Communication`: Add isCourseWide attribute to channel

### DIFF
--- a/Sources/SharedModels/Conversation/Channel.swift
+++ b/Sources/SharedModels/Conversation/Channel.swift
@@ -29,6 +29,7 @@ public struct Channel: BaseConversation {
     public var isPublic: Bool?
     public var isAnnouncementChannel: Bool?
     public var isArchived: Bool?
+    public var isCourseWide: Bool?
     public var hasChannelModerationRights: Bool?
     public var isChannelModerator: Bool?
     public var tutorialGroupId: Int?


### PR DESCRIPTION
`Channel`s have an attribute called `isCourseWide`, which we need for the iOS app as well.