### PR TITLE
`Communication`: Add profile picture support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -64,6 +64,7 @@ let package = Package(
                 "DesignLibrary",
                 "PushNotifications",
                 "SharedModels",
+                "SharedServices",
                 "UserStore",
                 .product(name: "RswiftLibrary", package: "R.swift")
             ],

--- a/Sources/Account/Resources/en.lproj/Localizable.strings
+++ b/Sources/Account/Resources/en.lproj/Localizable.strings
@@ -9,6 +9,7 @@
 "registrationNumberLabel" = "Registration Number";
 "joinedLabel" = "Joined Artemis on";
 "accountInformationNavigationTitle" = "Account Information";
+"changeProfilePicture" = "Your profile picture can be changed in Profile Settings on the web.";
 
 // MARK: General
 "close" = "Close";

--- a/Sources/Account/Views/AccountNavigationBarMenuView.swift
+++ b/Sources/Account/Views/AccountNavigationBarMenuView.swift
@@ -50,11 +50,22 @@ struct AccountNavigationBarMenuView: View {
         }, label: {
             HStack(alignment: .center, spacing: .s) {
                 Spacer()
-                Image(systemName: "person.fill")
-                Text(viewModel.account.value?.login ?? "xx12xxx")
-                    .redacted(reason: viewModel.account.value == nil ? .placeholder : [])
+                if let pictureUrl = viewModel.profilePicUrl {
+                    ArtemisAsyncImage(imageURL: pictureUrl) {
+                        Image(systemName: "person.fill")
+                    }
+                    .scaledToFit()
+                    .frame(width: 30, height: 30)
+                    .clipShape(.circle)
+                } else {
+                    Image(systemName: "person.fill")
+                    Text(viewModel.account.value?.login ?? "xx12xxx")
+                        .redacted(reason: viewModel.account.value == nil ? .placeholder : [])
+                }
                 Image(systemName: "arrowtriangle.down.fill")
-                    .scaleEffect(0.5)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 16, height: 10)
             }.frame(width: 150)
         })
         .onChange(of: viewModel.error) { _, error in

--- a/Sources/Account/Views/ProfileView.swift
+++ b/Sources/Account/Views/ProfileView.swift
@@ -5,6 +5,7 @@
 //  Created by Sven Andabaka on 19.05.23.
 //
 
+import DesignLibrary
 import SwiftUI
 import SharedModels
 
@@ -17,6 +18,17 @@ struct ProfileView: View {
     var body: some View {
         NavigationView {
             List {
+                if let pictureUrl = account.imagePath {
+                    Section {
+                        ArtemisAsyncImage(imageURL: pictureUrl) {}
+                            .frame(width: 70, height: 70)
+                            .clipShape(.circle)
+                            .frame(maxWidth: .infinity, alignment: .center)
+                            .listRowBackground(Color.clear)
+                    } footer: {
+                        Text(R.string.localizable.changeProfilePicture())
+                    }
+                }
                 Section(R.string.localizable.fullNameLabel()) {
                     Text(account.name)
                 }

--- a/Sources/Account/Views/ProfileView.swift
+++ b/Sources/Account/Views/ProfileView.swift
@@ -21,8 +21,8 @@ struct ProfileView: View {
                 if let pictureUrl = account.imagePath {
                     Section {
                         ArtemisAsyncImage(imageURL: pictureUrl) {}
-                            .frame(width: 70, height: 70)
-                            .clipShape(.circle)
+                            .frame(width: 100, height: 100)
+                            .clipShape(.rect(cornerRadius: .m))
                             .frame(maxWidth: .infinity, alignment: .center)
                             .listRowBackground(Color.clear)
                     } footer: {

--- a/Sources/SharedModels/Conversation/ConversationUser.swift
+++ b/Sources/SharedModels/Conversation/ConversationUser.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import UserStore
 
 public struct ConversationUser: UserPublicInfo {
     public var id: Int64
@@ -13,6 +14,7 @@ public struct ConversationUser: UserPublicInfo {
     public var name: String?
     public var firstName: String?
     public var lastName: String?
+    private var imageUrl: String?
     public var isInstructor: Bool?
     public var isEditor: Bool?
     public var isTeachingAssistant: Bool?
@@ -20,6 +22,14 @@ public struct ConversationUser: UserPublicInfo {
 
     public var isChannelModerator: Bool?
     public var isRequestingUser: Bool?
+
+    public var imagePath: URL? {
+        guard let imageUrl else { return nil }
+        guard let urlString = UserSessionFactory.shared.institution?.baseURL?.absoluteString.appending(imageUrl) else {
+            return nil
+        }
+        return URL(string: urlString)
+    }
 }
 
 public extension ConversationUser {

--- a/Sources/SharedModels/User/Account.swift
+++ b/Sources/SharedModels/User/Account.swift
@@ -7,6 +7,7 @@ public struct Account: Codable {
     public let name: String
     public let firstName: String
     public let lastName: String?
+    private let imageUrl: String?
     public let email: String
     public let langKey: String
     public let authorities: [Authority]?
@@ -35,6 +36,14 @@ public struct Account: Codable {
 
         return userAuthorities.contains(authority)
     }
+
+    public var imagePath: URL? {
+        guard let imageUrl else { return nil }
+        guard let urlString = UserSessionFactory.shared.institution?.baseURL?.absoluteString.appending(imageUrl) else {
+            return nil
+        }
+        return URL(string: urlString)
+    }
 }
 
 public extension Account {
@@ -44,6 +53,7 @@ public extension Account {
         name: "Chloe Mitchell",
         firstName: "Chloe",
         lastName: "Mitchell",
+        imageUrl: nil,
         email: "chloe_mitchell@gmail.com",
         langKey: "en",
         authorities: [.user],


### PR DESCRIPTION
In order to add profile pictures, we need Accounts to have a `imageUrl` attribute that represents the path to the account's profile picture if available.

We also add a `imagePath` helper attribute to convert this relative path into an absolute one for use in `ArtemisAsyncImage`.

The user's profile picture is also displayed on the ProfileInfo sheet.