### PR TITLE
`Communication`/`Notification`: Show message content in DM notifications

### DIFF
--- a/Sources/PushNotifications/Models/PushNotification.swift
+++ b/Sources/PushNotifications/Models/PushNotification.swift
@@ -385,10 +385,12 @@ public enum PushNotificationType: String, Codable {
                                                                                                     notificationPlaceholders[4])
             case "groupChat":
                 return R.string.localizable.artemisAppConversationNotificationTextNewMessageGroupChat(notificationPlaceholders[0],
-                                                                                                      notificationPlaceholders[3])
+                                                                                                      notificationPlaceholders[4],
+                                                                                                      notificationPlaceholders[1])
             case "oneToOneChat":
                 return R.string.localizable.artemisAppConversationNotificationTextNewMessageDirect(notificationPlaceholders[0],
-                                                                                                   notificationPlaceholders[3])
+                                                                                                   notificationPlaceholders[4],
+                                                                                                   notificationPlaceholders[1])
             default:
                 return nil
             }

--- a/Sources/PushNotifications/Resources/en.lproj/Localizable.strings
+++ b/Sources/PushNotifications/Resources/en.lproj/Localizable.strings
@@ -135,8 +135,8 @@
 "artemisApp.singleUserNotification.text.newPlagiarismCaseStudent" = "New plagiarism case concerning the %1$@ exercise \"%2$@\".";
 "artemisApp.singleUserNotification.text.plagiarismCaseVerdictStudent" = "Your plagiarism case concerning the %1$@ exercise \"%2$@\" has a verdict.";
 "artemisApp.conversationNotification.text.newMessageChannel" = "New message in %2$@ channel from %3$@ in course %1$@.";
-"artemisApp.conversationNotification.text.newMessageGroupChat" = "New message in group chat from %2$@ in course %1$@.";
-"artemisApp.conversationNotification.text.newMessageDirect" = "New direct message from %2$@ in course %1$@.";
+"artemisApp.conversationNotification.text.newMessageGroupChat" = "New message in group chat from %2$@ in course %1$@:\n%3$@";
+"artemisApp.conversationNotification.text.newMessageDirect" = "New direct message from %2$@ in course %1$@:\n%3$@";
 "artemisApp.singleUserNotification.text.messageReply" = "You have new reply in a message by %2$@ in course %1$@.";
 
 "artemisApp.groupNotification.text.exerciseUpdated" = "The exercise \"%2$@\" in course \"%1$@\" got updated.";


### PR DESCRIPTION
### Problem
Notifications for DMs or Group DMs currently look like this:
> **New Message**
> New direct message from Anian Schleyer in course Test.

This is a bad user experience since we don't show the message content.

### Solution
We change these notification to look like this:
> **New Message**
> New direct message from Anian Schleyer in course Test:
> Message Content Here