### PR TITLE
`Communication`: Fix profile pictures not being shown

### DIFF
--- a/Sources/SharedModels/Conversation/ConversationUser.swift
+++ b/Sources/SharedModels/Conversation/ConversationUser.swift
@@ -24,11 +24,12 @@ public struct ConversationUser: UserPublicInfo {
     public var isRequestingUser: Bool?
 
     public var imagePath: URL? {
-        guard let imageUrl else { return nil }
-        guard let urlString = UserSessionFactory.shared.institution?.baseURL?.absoluteString.appending(imageUrl) else {
-            return nil
+        guard var imageUrl else { return nil }
+        if imageUrl.starts(with: "/") {
+            imageUrl.removeFirst()
         }
-        return URL(string: urlString)
+        let baseUrl = UserSessionFactory.shared.institution?.baseURL
+        return baseUrl?.appending(path: imageUrl)
     }
 }
 

--- a/Sources/SharedModels/User/Account.swift
+++ b/Sources/SharedModels/User/Account.swift
@@ -38,11 +38,12 @@ public struct Account: Codable {
     }
 
     public var imagePath: URL? {
-        guard let imageUrl else { return nil }
-        guard let urlString = UserSessionFactory.shared.institution?.baseURL?.absoluteString.appending(imageUrl) else {
-            return nil
+        guard var imageUrl else { return nil }
+        if imageUrl.starts(with: "/") {
+            imageUrl.removeFirst()
         }
-        return URL(string: urlString)
+        let baseUrl = UserSessionFactory.shared.institution?.baseURL
+        return baseUrl?.appending(path: imageUrl)
     }
 }
 


### PR DESCRIPTION
Due to some server urls being entered with a trailing slash and some without, profile images failed to load if the user was on a server with a trailing slash in its url.