### PR TITLE
`Notifications`: Fix non course wide channel message notification content

### DIFF
--- a/Sources/PushNotifications/Models/PushNotification.swift
+++ b/Sources/PushNotifications/Models/PushNotification.swift
@@ -380,9 +380,10 @@ public enum PushNotificationType: String, Codable {
             guard notificationPlaceholders.count > 5 else { return nil }
             switch notificationPlaceholders[5] {
             case "channel":
-                return R.string.localizable.artemisAppConversationNotificationTextNewMessageChannel(notificationPlaceholders[0],
-                                                                                                    notificationPlaceholders[3],
-                                                                                                    notificationPlaceholders[4])
+                return R.string.localizable.artemisAppConversationNotificationTextNewMessageChannel(notificationPlaceholders[3],
+                                                                                                    notificationPlaceholders[0],
+                                                                                                    notificationPlaceholders[4],
+                                                                                                    notificationPlaceholders[1])
             case "groupChat":
                 return R.string.localizable.artemisAppConversationNotificationTextNewMessageGroupChat(notificationPlaceholders[0],
                                                                                                       notificationPlaceholders[4],

--- a/Sources/PushNotifications/Resources/en.lproj/Localizable.strings
+++ b/Sources/PushNotifications/Resources/en.lproj/Localizable.strings
@@ -134,7 +134,7 @@
 "artemisApp.singleUserNotification.text.fileSubmissionSuccessful" = "Your file for the exercise \"%1$@\" was successfully submitted.";
 "artemisApp.singleUserNotification.text.newPlagiarismCaseStudent" = "New plagiarism case concerning the %1$@ exercise \"%2$@\".";
 "artemisApp.singleUserNotification.text.plagiarismCaseVerdictStudent" = "Your plagiarism case concerning the %1$@ exercise \"%2$@\" has a verdict.";
-"artemisApp.conversationNotification.text.newMessageChannel" = "New message in %2$@ channel from %3$@ in course %1$@.";
+"artemisApp.conversationNotification.text.newMessageChannel" = "New message in %2$@ channel from %3$@ in course %1$@:\n%4$@";
 "artemisApp.conversationNotification.text.newMessageGroupChat" = "New message in group chat from %2$@ in course %1$@:\n%3$@";
 "artemisApp.conversationNotification.text.newMessageDirect" = "New direct message from %2$@ in course %1$@:\n%3$@";
 "artemisApp.singleUserNotification.text.messageReply" = "You have new reply in a message by %2$@ in course %1$@.";


### PR DESCRIPTION
Non course wide channel notifications are missing the message content, and author/channel names are swapped.