### PR TITLE
`Notifications`: Correct channel name for exercise/lecture notifications

### DIFF
--- a/Sources/PushNotifications/Models/PushNotification.swift
+++ b/Sources/PushNotifications/Models/PushNotification.swift
@@ -302,11 +302,11 @@ public enum PushNotificationType: String, Codable {
         case .newExercisePost:
             guard notificationPlaceholders.count > 4 else { return nil }
             return R.string.localizable.artemisAppGroupNotificationTextNewExercisePost(notificationPlaceholders[1],
-                                                                                       notificationPlaceholders[4])
+                                                                                       notificationPlaceholders[3])
         case .newLecturePost:
             guard notificationPlaceholders.count > 4 else { return nil }
             return R.string.localizable.artemisAppGroupNotificationTextNewLecturePost(notificationPlaceholders[1],
-                                                                                      notificationPlaceholders[4])
+                                                                                      notificationPlaceholders[3])
         //
         case .courseArchiveStarted:
             guard notificationPlaceholders.count > 0 else { return nil }


### PR DESCRIPTION
Due to the previously wrong order of channel and author name in notification placeholders, the content of exercise and lecture post notifications is currently showing the author's name instead of the exercise/lecture's title.