### PR TITLE
`General`: Fix users not being able to use app without "Remember me"

### DIFF
--- a/Sources/Account/ViewModels/AccountNavigationBarMenuViewModel.swift
+++ b/Sources/Account/ViewModels/AccountNavigationBarMenuViewModel.swift
@@ -28,9 +28,6 @@ class AccountNavigationBarMenuViewModel: ObservableObject {
         if let user = UserSessionFactory.shared.user {
             account = .done(response: user)
             profilePicUrl = account.value?.imagePath
-            Task {
-                await updateProfilePicUrl()
-            }
         } else {
             account = .loading
         }

--- a/Sources/UserStore/UserSession.swift
+++ b/Sources/UserStore/UserSession.swift
@@ -97,8 +97,7 @@ public class UserSession: ObservableObject {
     }
 
     public func saveNotificationDeviceConfiguration(token: String?, encryptionKey: String?, skippedNotifications: Bool) {
-        guard let institution,
-              let username else { return }
+        guard let institution else { return }
         let notificationDeviceConfiguration = NotificationDeviceConfiguration(institutionIdentifier: institution,
                                                                               username: username,
                                                                               skippedNotifications: skippedNotifications,
@@ -144,7 +143,7 @@ public class UserSession: ObservableObject {
 
 public struct NotificationDeviceConfiguration: Codable {
     var institutionIdentifier: InstitutionIdentifier
-    var username: String
+    var username: String?
     public var skippedNotifications: Bool
     public var apnsDeviceToken: String?
     public var notificationsEncryptionKey: String?


### PR DESCRIPTION
When users had disabled "Remember me" on the login screen, they could not continue from the notification setup screen and thus not use the app.