### PR TITLE
`Courses`: Add faqEnabled attribute to course

### DIFF
--- a/Sources/SharedModels/Course/Course.swift
+++ b/Sources/SharedModels/Course/Course.swift
@@ -25,6 +25,7 @@ public struct Course: Codable, Identifiable {
     public var instructorGroupName: String?
     public var editorGroupName: String?
     public var teachingAssistantGroupName: String?
+    public var faqEnabled: Bool?
 
     // helper attributes, if DTO does not contain complete data
     public var numberOfLectures: Int?


### PR DESCRIPTION
In order to show FAQs, we need to fetch whether a course has FAQs enabled. This PR adds the corresponding attribute to `Course`.