### PR TITLE
`General`: Fix keychain items not being accessible when device is locked

### DIFF
--- a/Sources/UserStore/KeychainHelper.swift
+++ b/Sources/UserStore/KeychainHelper.swift
@@ -20,7 +20,7 @@ final class KeychainHelper {
             kSecClass: kSecClassGenericPassword,
             kSecAttrService: service,
             kSecAttrAccount: account,
-            kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlock
+            kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
         ] as CFDictionary
 
         // Add data in query to keychain
@@ -37,7 +37,7 @@ final class KeychainHelper {
                 kSecAttrService: service,
                 kSecAttrAccount: account,
                 kSecClass: kSecClassGenericPassword,
-                kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlock
+                kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
             ] as CFDictionary
 
             let attributesToUpdate = [kSecValueData: data] as CFDictionary

--- a/Sources/UserStore/KeychainHelper.swift
+++ b/Sources/UserStore/KeychainHelper.swift
@@ -19,7 +19,8 @@ final class KeychainHelper {
             kSecValueData: data,
             kSecClass: kSecClassGenericPassword,
             kSecAttrService: service,
-            kSecAttrAccount: account
+            kSecAttrAccount: account,
+            kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlock
         ] as CFDictionary
 
         // Add data in query to keychain
@@ -35,7 +36,8 @@ final class KeychainHelper {
             let query = [
                 kSecAttrService: service,
                 kSecAttrAccount: account,
-                kSecClass: kSecClassGenericPassword
+                kSecClass: kSecClassGenericPassword,
+                kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlock
             ] as CFDictionary
 
             let attributesToUpdate = [kSecValueData: data] as CFDictionary

--- a/Sources/UserStore/UserSession.swift
+++ b/Sources/UserStore/UserSession.swift
@@ -30,7 +30,7 @@ public class UserSession: ObservableObject {
     }
 
     private func setupInstitutionSelection() {
-        if let institutionData = KeychainHelper.shared.read(service: "institution", account: "Artemis") {
+        if let institutionData = KeychainHelper.shared.read(service: .institutionKey, account: "Artemis") {
             institution = InstitutionIdentifier(value: String(decoding: institutionData, as: UTF8.self))
         } else {
             institution = .tum
@@ -39,7 +39,7 @@ public class UserSession: ObservableObject {
     }
 
     private func setupNotificationData() {
-        if let notificationDeviceConfigurationData = KeychainHelper.shared.read(service: "notificationDeviceConfigurations", account: "Artemis") {
+        if let notificationDeviceConfigurationData = KeychainHelper.shared.read(service: .notificationConfigKey, account: "Artemis") {
             let decoder = JSONDecoder()
             do {
                 notificationDeviceConfigurations = try decoder.decode([NotificationDeviceConfiguration].self, from: notificationDeviceConfigurationData)
@@ -51,15 +51,15 @@ public class UserSession: ObservableObject {
     }
 
     private func setupLoginData() {
-        if let tokenData = KeychainHelper.shared.read(service: "isLoggedIn", account: "Artemis") {
+        if let tokenData = KeychainHelper.shared.read(service: .isLoggedInKey, account: "Artemis") {
             isLoggedIn = String(decoding: tokenData, as: UTF8.self) == "true"
         }
 
-        if let username = KeychainHelper.shared.read(service: "username", account: "Artemis") {
+        if let username = KeychainHelper.shared.read(service: .usernameKey, account: "Artemis") {
             self.username = String(decoding: username, as: UTF8.self)
         }
 
-        if let password = KeychainHelper.shared.read(service: "password", account: "Artemis") {
+        if let password = KeychainHelper.shared.read(service: .passwordKey, account: "Artemis") {
             self.password = String(decoding: password, as: UTF8.self)
         }
     }
@@ -71,7 +71,7 @@ public class UserSession: ObservableObject {
     public func setUserLoggedIn(isLoggedIn: Bool) {
         self.isLoggedIn = isLoggedIn
         let isLoggedInData = Data(isLoggedIn.description.utf8)
-        KeychainHelper.shared.save(isLoggedInData, service: "isLoggedIn", account: "Artemis")
+        KeychainHelper.shared.save(isLoggedInData, service: .isLoggedInKey, account: "Artemis")
     }
 
     public func saveUsername(username: String?) {
@@ -79,9 +79,9 @@ public class UserSession: ObservableObject {
 
         if let username {
             let usernameData = Data(username.description.utf8)
-            KeychainHelper.shared.save(usernameData, service: "username", account: "Artemis")
+            KeychainHelper.shared.save(usernameData, service: .usernameKey, account: "Artemis")
         } else {
-            KeychainHelper.shared.delete(service: "username", account: "Artemis")
+            KeychainHelper.shared.delete(service: .usernameKey, account: "Artemis")
         }
     }
 
@@ -90,9 +90,9 @@ public class UserSession: ObservableObject {
 
         if let password {
             let passwordData = Data(password.description.utf8)
-            KeychainHelper.shared.save(passwordData, service: "password", account: "Artemis")
+            KeychainHelper.shared.save(passwordData, service: .passwordKey, account: "Artemis")
         } else {
-            KeychainHelper.shared.delete(service: "password", account: "Artemis")
+            KeychainHelper.shared.delete(service: .passwordKey, account: "Artemis")
         }
     }
 
@@ -112,7 +112,7 @@ public class UserSession: ObservableObject {
 
         let encoder = JSONEncoder()
         if let encodedData = try? encoder.encode(notificationDeviceConfigurations) {
-            KeychainHelper.shared.save(encodedData, service: "notificationDeviceConfigurations", account: "Artemis")
+            KeychainHelper.shared.save(encodedData, service: .notificationConfigKey, account: "Artemis")
         }
     }
 
@@ -125,19 +125,19 @@ public class UserSession: ObservableObject {
 
         if let identifier {
             let identifierData = Data(identifier.value.utf8)
-            KeychainHelper.shared.save(identifierData, service: "institution", account: "Artemis")
+            KeychainHelper.shared.save(identifierData, service: .institutionKey, account: "Artemis")
         } else {
-            KeychainHelper.shared.delete(service: "institution", account: "Artemis")
+            KeychainHelper.shared.delete(service: .institutionKey, account: "Artemis")
         }
     }
 
     // only used for debugging
     public func wipeKeychain() {
-        KeychainHelper.shared.delete(service: "username", account: "Artemis")
-        KeychainHelper.shared.delete(service: "isLoggedIn", account: "Artemis")
-        KeychainHelper.shared.delete(service: "password", account: "Artemis")
-        KeychainHelper.shared.delete(service: "institution", account: "Artemis")
-        KeychainHelper.shared.delete(service: "notificationDeviceConfigurations", account: "Artemis")
+        KeychainHelper.shared.delete(service: .usernameKey, account: "Artemis")
+        KeychainHelper.shared.delete(service: .isLoggedInKey, account: "Artemis")
+        KeychainHelper.shared.delete(service: .passwordKey, account: "Artemis")
+        KeychainHelper.shared.delete(service: .institutionKey, account: "Artemis")
+        KeychainHelper.shared.delete(service: .notificationConfigKey, account: "Artemis")
     }
 }
 
@@ -147,4 +147,12 @@ public struct NotificationDeviceConfiguration: Codable {
     public var skippedNotifications: Bool
     public var apnsDeviceToken: String?
     public var notificationsEncryptionKey: String?
+}
+
+fileprivate extension String {
+    static let usernameKey = "Username"
+    static let passwordKey = "Password"
+    static let notificationConfigKey = "NotificationConfigurations"
+    static let institutionKey = "Institution"
+    static let isLoggedInKey = "LoginStatus"
 }


### PR DESCRIPTION
Keychain items are not accessible when the device is locked. But we need this, so we switch to the `afterFirstUnlock` policy instead of `whenUnlocked`.