### PR TITLE
`Communication`: *Breaking* Add profile picture to conversation icon

### DIFF
--- a/Sources/SharedModels/Conversation/BaseConversation.swift
+++ b/Sources/SharedModels/Conversation/BaseConversation.swift
@@ -42,7 +42,7 @@ public protocol BaseConversation: Codable {
 
     // computed properties
     var conversationName: String { get }
-    var icon: Image? { get }
+    var icon: AnyView? { get }
 }
 
 public enum Conversation: Codable, Identifiable {

--- a/Sources/SharedModels/Conversation/Channel.swift
+++ b/Sources/SharedModels/Conversation/Channel.swift
@@ -43,17 +43,17 @@ public struct Channel: BaseConversation {
         return name ?? ""
     }
 
-    public var icon: Image? {
+    public var icon: AnyView? {
         if isArchived ?? false {
-            return Image(systemName: "archivebox.fill")
+            return AnyView(Image(systemName: "archivebox.fill").resizable())
         }
         if isAnnouncementChannel ?? false {
-            return Image(systemName: "megaphone.fill")
+            return AnyView(Image(systemName: "megaphone.fill").resizable())
         }
         if isPublic ?? false {
-            return Image(systemName: "number")
+            return AnyView(Image(systemName: "number").resizable())
         }
-        return Image(systemName: "lock.fill")
+        return AnyView(Image(systemName: "lock.fill").resizable())
     }
 
     public static let mock = Channel(

--- a/Sources/SharedModels/Conversation/GroupChat.swift
+++ b/Sources/SharedModels/Conversation/GroupChat.swift
@@ -43,8 +43,8 @@ public struct GroupChat: BaseConversation {
         return "\(membersWithoutUser.map { $0.name ?? "" }.prefix(2).joined(separator: ", ")), \(R.string.localizable.others(membersWithoutUser.count - 2))"
     }
 
-    public var icon: Image? {
-        Image(systemName: "person.3.fill")
+    public var icon: AnyView? {
+        AnyView(Image(systemName: "person.3.fill").resizable())
     }
 }
 

--- a/Sources/SharedModels/Conversation/OneToOneChat.swift
+++ b/Sources/SharedModels/Conversation/OneToOneChat.swift
@@ -5,6 +5,7 @@
 //  Created by Sven Andabaka on 05.04.23.
 //
 
+import DesignLibrary
 import Foundation
 import SwiftUI
 
@@ -25,13 +26,27 @@ public struct OneToOneChat: BaseConversation {
 
     public var members: [ConversationUser]?
 
-    public var conversationName: String {
-        let otherUser = (members ?? []).first(where: { $0.isRequestingUser == false })
-        return otherUser?.name ?? ""
+    private var otherUser: ConversationUser? {
+        (members ?? []).first(where: { $0.isRequestingUser == false })
     }
 
-    public var icon: Image? {
-        Image(systemName: "lock.fill")
+    public var conversationName: String {
+        otherUser?.name ?? ""
+    }
+
+    public var icon: AnyView? {
+        if let imagePath = otherUser?.imagePath {
+            AnyView(
+                ArtemisAsyncImage(imageURL: imagePath) {
+                    Image(systemName: "lock.fill")
+                        .resizable()
+                }
+                .frame(width: 30, height: 30)
+                .clipShape(.rect(cornerRadius: .s))
+            )
+        } else {
+            AnyView(Image(systemName: "lock.fill").resizable())
+        }
     }
 }
 

--- a/Sources/SharedModels/Conversation/UnknownConversation.swift
+++ b/Sources/SharedModels/Conversation/UnknownConversation.swift
@@ -27,7 +27,7 @@ public struct UnknownConversation: BaseConversation {
         return "?"
     }
 
-    public var icon: Image? {
+    public var icon: AnyView? {
         nil
     }
 }


### PR DESCRIPTION
This PR replaces the icon for direct messages with the user's profile picture whenever available.