### PR TITLE
`Chore`: Fix logout function name typo

### DIFF
--- a/Sources/APIClient/APIClient.swift
+++ b/Sources/APIClient/APIClient.swift
@@ -183,7 +183,7 @@ public final class APIClient {
         return bodyData
     }
 
-    public func perfomLogout() {
+    public func performLogout() {
         log.debug("Logging user out")
         DispatchQueue.main.async {
             Task {
@@ -197,7 +197,7 @@ public final class APIClient {
 
     private func logoutAndSetTokenExpired() {
         log.debug("Token could not be refreshed")
-        perfomLogout()
+        performLogout()
         UserSessionFactory.shared.setTokenExpired(expired: true)
     }
 }

--- a/Sources/Account/ViewModels/AccountNavigationBarMenuViewModel.swift
+++ b/Sources/Account/ViewModels/AccountNavigationBarMenuViewModel.swift
@@ -47,7 +47,7 @@ class AccountNavigationBarMenuViewModel: ObservableObject {
                         encryptionKey: nil,
                         skippedNotifications: notificationDeviceConfiguration.skippedNotifications)
                 }
-                APIClient().perfomLogout()
+                APIClient().performLogout()
             case .failure(let error):
                 if let error = error as? APIClientError {
                     switch error {
@@ -55,12 +55,12 @@ class AccountNavigationBarMenuViewModel: ObservableObject {
                         if statusCode == .methodNotAllowed {
                             // ignore network error and login anyway
                             // TODO: schedule task to retry above functionality
-                            APIClient().perfomLogout()
+                            APIClient().performLogout()
                         }
                     case .networkError:
                         // ignore network error and login anyway
                         // TODO: schedule task to retry above functionality
-                        APIClient().perfomLogout()
+                        APIClient().performLogout()
                     default:
                         // do nothing
                         break


### PR DESCRIPTION
The function to log out is called `perfomLogout` instead of `performLogout`. We fix this.