### PR TITLE
`ArtemisStompClient`: Fix data concurrency/race crash

### DIFF
--- a/Sources/APIClient/StompClient/ArtemisStompClient.swift
+++ b/Sources/APIClient/StompClient/ArtemisStompClient.swift
@@ -104,8 +104,9 @@ extension ArtemisStompClient: SwiftStompDelegate {
 
     public func onConnect(swiftStomp: SwiftStomp, connectType: StompConnectType) {
         log.debug("Stomp: Connect")
-        topics.forEach { topic in
-            subscribeWithoutStream(to: topic.key)
+        let topicKeys = Array(topics.keys)
+        topicKeys.forEach { topic in
+            subscribeWithoutStream(to: topic)
         }
     }
 


### PR DESCRIPTION
There are lots of crashes in Artemis iOS caused by SwiftStomp calling `self.delegate?.onConnect(swiftStomp: self, connectType: .toSocketEndpoint)`. This means there is a problem in `ArtemisStompClient.onConnect`. I've identified this as a data race issue.