### PR TITLE
`StompClient`: Unzip compressed websocket messages

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -19,6 +19,15 @@
       }
     },
     {
+      "identity" : "gzipswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/1024jp/GzipSwift.git",
+      "state" : {
+        "revision" : "56bf51fdd2fe4b2cf254b2cf34aede3d7caccc6c",
+        "version" : "6.1.0"
+      }
+    },
+    {
       "identity" : "kingfisher",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/onevcat/Kingfisher.git",
@@ -50,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ashleymills/Reachability.swift",
       "state" : {
-        "revision" : "98e968e7b6c1318fb61df23e347bc319761e8acb",
-        "version" : "5.0.0"
+        "revision" : "21d1dc412cfecbe6e34f1f4c4eb88d3f912654a6",
+        "version" : "5.2.4"
       }
     },
     {
@@ -61,15 +70,6 @@
       "state" : {
         "revision" : "fd4df99170f5e9d7cf9aa8312aa8506e0e7a44e7",
         "version" : "0.35.0"
-      }
-    },
-    {
-      "identity" : "starscream",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/daltoniam/Starscream.git",
-      "state" : {
-        "revision" : "df8d82047f6654d8e4b655d1b1525c64e1059d21",
-        "version" : "4.0.4"
       }
     },
     {
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Romixery/SwiftStomp.git",
       "state" : {
-        "revision" : "99dcfa7f428485b92de2359c9df9c778fd2d5599",
-        "version" : "1.1.1"
+        "revision" : "f25926d2ab67ec0391de9a706cf71dfb08d36bbc",
+        "version" : "1.2.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -52,6 +52,7 @@ let package = Package(
         .package(url: "https://github.com/Romixery/SwiftStomp.git", .upToNextMinor(from: "1.2.1")),
         .package(url: "https://github.com/realm/SwiftLint.git", .upToNextMinor(from: "0.55.0")),
         .package(url: "https://github.com/SwiftyBeaver/SwiftyBeaver.git", .upToNextMajor(from: "1.9.0")),
+        .package(url: "https://github.com/1024jp/GzipSwift.git", .upToNextMajor(from: "6.1.0")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -77,7 +78,8 @@ let package = Package(
             dependencies: [
                 "Common",
                 "SwiftStomp",
-                "UserStore"
+                "UserStore",
+                .product(name: "Gzip", package: "GzipSwift")
             ],
             plugins: [
                 .plugin(name: "SwiftLintBuildToolPlugin", package: "SwiftLint")

--- a/Sources/APIClient/StompClient/ArtemisStompClient.swift
+++ b/Sources/APIClient/StompClient/ArtemisStompClient.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Gzip
 import SwiftStomp
 import UserStore
 import Common
@@ -125,7 +126,14 @@ extension ArtemisStompClient: SwiftStompDelegate {
     public func onMessageReceived(swiftStomp: SwiftStomp, message: Any?, messageId: String, destination: String, headers: [String: String]) {
         log.debug("Stomp: MessageReceived")
         let continuation = continuations[destination]
-        continuation?.yield(message)
+
+        if headers["compressed"] == "true" {
+            if let unzipped = try? (message as? Data)?.gunzipped() {
+                continuation?.yield(unzipped)
+            }
+        } else {
+            continuation?.yield(message)
+        }
     }
 
     public func onReceipt(swiftStomp: SwiftStomp, receiptId: String) {

--- a/Sources/APIClient/StompClient/ArtemisStompClient.swift
+++ b/Sources/APIClient/StompClient/ArtemisStompClient.swift
@@ -130,6 +130,8 @@ extension ArtemisStompClient: SwiftStompDelegate {
         if headers["compressed"] == "true" {
             if let unzipped = try? (message as? Data)?.gunzipped() {
                 continuation?.yield(unzipped)
+            } else {
+                log.warning("Stomp: Failed to gunzip compressed message")
             }
         } else {
             continuation?.yield(message)


### PR DESCRIPTION
If a message is received on the web socket with `compressed: true` header, this indicates the payload is compressed. Thus, we uncompress it using gzip.