### PR TITLE
`DesignLibrary`: Fix progress bar being messed up when at over 100%

### DIFF
--- a/Sources/DesignLibrary/ProgressBar.swift
+++ b/Sources/DesignLibrary/ProgressBar.swift
@@ -34,7 +34,7 @@ public struct ProgressBar: View {
         backgroundColor: Color = Color.Artemis.courseScoreProgressBackgroundColor,
         ringColor: Color = Color.Artemis.courseScoreProgressRingColor
     ) {
-        self.value = Int(value)
+        self.value = Int(min(value, total)) // Cap at 100%
         self.total = Int(total)
         self.percentage = Int((value * 100 / total).rounded())
         self.backgroundColor = backgroundColor


### PR DESCRIPTION
![IMG_9365](https://github.com/user-attachments/assets/cb7e2694-9066-429b-82b0-d5f11ba3e521)
