### PR TITLE
`Notifications`: Add version code to push notification registration

### DIFF
--- a/Sources/PushNotifications/Services/PushNotificationService/PushNotificationServiceImpl.swift
+++ b/Sources/PushNotifications/Services/PushNotificationService/PushNotificationServiceImpl.swift
@@ -61,6 +61,7 @@ class PushNotificationServiceImpl: PushNotificationService {
         var token: String
         var deviceType = "APNS"
         var apiType = 1
+        var versionCode = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
 
         var method: HTTPMethod {
             return .post


### PR DESCRIPTION
In order to keep track of Artemis mobile app version usage, we add the version code to the registration.