### PR TITLE
`Notifications`: Add course notifications

### DIFF
--- a/Sources/PushNotifications/Models/Communication/NewPostNotification.swift
+++ b/Sources/PushNotifications/Models/Communication/NewPostNotification.swift
@@ -22,7 +22,7 @@ public class NewPostNotification: CourseBaseNotification {
 
 extension NewPostNotification: DisplayableNotification {
     public var title: String {
-        "New message"
+        R.string.localizable.artemisAppConversationNotificationTitleNewMessage()
     }
 
     public var subtitle: String? {

--- a/Sources/PushNotifications/Models/Communication/NewPostNotification.swift
+++ b/Sources/PushNotifications/Models/Communication/NewPostNotification.swift
@@ -1,0 +1,35 @@
+//
+//  NewPostNotification.swift
+//  ArtemisCore
+//
+//  Created by Anian Schleyer on 23.03.25.
+//
+
+public class NewPostNotification: CourseBaseNotification {
+    public let courseId: Int?
+    public let courseTitle: String?
+    public let courseIconUrl: String?
+
+    public let postId: Int?
+    public let postMarkdownContent: String?
+    public let channelId: Int?
+    public let channelName: String?
+    public let channelType: String?
+    public let authorName: String?
+    public let authorImageUrl: String?
+    public let authorId: Int?
+}
+
+extension NewPostNotification: DisplayableNotification {
+    public var title: String {
+        "New message"
+    }
+
+    public var subtitle: String? {
+        authorName
+    }
+
+    public var body: String? {
+        postMarkdownContent
+    }
+}

--- a/Sources/PushNotifications/Models/CoursePushNotification.swift
+++ b/Sources/PushNotifications/Models/CoursePushNotification.swift
@@ -18,15 +18,21 @@ public enum CoursePushNotification: Codable {
     case newPost(notification: NewPostNotification)
     case unknown
 
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: Keys.self)
-        let type = try container.decode(CourseNotificationType.self, forKey: Keys.type)
+    /// Initializer for using different CodingKeys.
+    /// This is necessary because Notifications that aren't push notifications have a different name for `type`.
+    public init<Key>(from decoder: Decoder, typeKey: Key, parametersKey: Key) throws where Key: CodingKey {
+        let container = try decoder.container(keyedBy: Key.self)
+        let type = try container.decode(CourseNotificationType.self, forKey: typeKey)
         switch type {
         case .newPostNotification:
-            self = .newPost(notification: try container.decode(NewPostNotification.self, forKey: Keys.parameters))
+            self = .newPost(notification: try container.decode(NewPostNotification.self, forKey: parametersKey))
         case .unknown:
             self = .unknown
         }
+    }
+
+    public init(from decoder: Decoder) throws {
+        try self.init(from: decoder, typeKey: Keys.type, parametersKey: Keys.parameters)
     }
 
     /// Not needed, but we conform to Codable to prevent annoyances in `PushNotification`

--- a/Sources/PushNotifications/Models/CoursePushNotification.swift
+++ b/Sources/PushNotifications/Models/CoursePushNotification.swift
@@ -37,6 +37,15 @@ public enum CoursePushNotification: Codable {
 
     /// Not needed, but we conform to Codable to prevent annoyances in `PushNotification`
     public func encode(to encoder: Encoder) throws {}
+
+    public var displayable: DisplayableNotification? {
+        switch self {
+        case .newPost(let notification):
+            notification
+        default:
+            nil
+        }
+    }
 }
 
 public enum CourseNotificationType: String, Codable, ConstantsEnum {
@@ -50,17 +59,12 @@ public protocol CourseBaseNotification: Codable {
     var courseIconUrl: String? { get }
 }
 
-public class NewPostNotification: CourseBaseNotification {
-    public let courseId: Int?
-    public let courseTitle: String?
-    public let courseIconUrl: String?
+public protocol DisplayableNotification {
+    var title: String { get }
+    var subtitle: String? { get }
+    var body: String? { get }
+}
 
-    public let postId: Int?
-    public let postMarkdownContent: String?
-    public let channelId: Int?
-    public let channelName: String?
-    public let channelType: String?
-    public let authorName: String?
-    public let authorImageUrl: String?
-    public let authorId: Int?
+public extension DisplayableNotification {
+    var bodyLineLimit: Int { 3 }
 }

--- a/Sources/PushNotifications/Models/CoursePushNotification.swift
+++ b/Sources/PushNotifications/Models/CoursePushNotification.swift
@@ -1,0 +1,60 @@
+//
+//  CoursePushNotification.swift
+//  ArtemisCore
+//
+//  Created by Anian Schleyer on 11.03.25.
+//
+
+import Foundation
+import SharedModels
+
+public enum CoursePushNotification: Codable {
+
+    fileprivate enum Keys: String, CodingKey {
+        case type
+        case parameters
+    }
+
+    case newPost(notification: NewPostNotification)
+    case unknown
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: Keys.self)
+        let type = try container.decode(CourseNotificationType.self, forKey: Keys.type)
+        switch type {
+        case .newPostNotification:
+            self = .newPost(notification: try container.decode(NewPostNotification.self, forKey: Keys.parameters))
+        case .unknown:
+            self = .unknown
+        }
+    }
+
+    /// Not needed, but we conform to Codable to prevent annoyances in `PushNotification`
+    public func encode(to encoder: Encoder) throws {}
+}
+
+enum CourseNotificationType: String, Codable, ConstantsEnum {
+    case newPostNotification
+    case unknown
+}
+
+public protocol CourseBaseNotification: Codable {
+    var courseId: Int? { get }
+    var courseTitle: String? { get }
+    var courseIconUrl: String? { get }
+}
+
+public class NewPostNotification: CourseBaseNotification {
+    public let courseId: Int?
+    public let courseTitle: String?
+    public let courseIconUrl: String?
+
+    public let postId: Int?
+    public let postMarkdownContent: String?
+    public let channelId: Int?
+    public let channelName: String?
+    public let channelType: String?
+    public let authorName: String?
+    public let authorImageUrl: String?
+    public let authorId: Int?
+}

--- a/Sources/PushNotifications/Models/CoursePushNotification.swift
+++ b/Sources/PushNotifications/Models/CoursePushNotification.swift
@@ -33,7 +33,7 @@ public enum CoursePushNotification: Codable {
     public func encode(to encoder: Encoder) throws {}
 }
 
-enum CourseNotificationType: String, Codable, ConstantsEnum {
+public enum CourseNotificationType: String, Codable, ConstantsEnum {
     case newPostNotification
     case unknown
 }

--- a/Sources/PushNotifications/Models/PushNotification.swift
+++ b/Sources/PushNotifications/Models/PushNotification.swift
@@ -29,6 +29,7 @@ struct PushNotification: Codable {
     let target: String
     let type: PushNotificationType
     let version: Int
+    let courseNotificationDTO: CoursePushNotification?
 
     var title: String? {
         type.title

--- a/Sources/SharedModels/ConstantsEnum.swift
+++ b/Sources/SharedModels/ConstantsEnum.swift
@@ -13,7 +13,7 @@ import Foundation
 /// ```swift
 /// public enum ProgrammingLanguage: String, ConstantsEnum {
 ///     case java = "JAVA"
-///     case swift = "SWIFT
+///     case swift = "SWIFT"
 ///     case unknown
 /// }
 /// ```

--- a/Sources/SharedModels/Course/Course.swift
+++ b/Sources/SharedModels/Course/Course.swift
@@ -26,7 +26,6 @@ public struct Course: Codable, Identifiable {
     public var editorGroupName: String?
     public var teachingAssistantGroupName: String?
     public var faqEnabled: Bool?
-    public var courseNotificationCount: Int?
 
     // helper attributes, if DTO does not contain complete data
     public var numberOfLectures: Int?

--- a/Sources/SharedModels/Course/Course.swift
+++ b/Sources/SharedModels/Course/Course.swift
@@ -26,6 +26,7 @@ public struct Course: Codable, Identifiable {
     public var editorGroupName: String?
     public var teachingAssistantGroupName: String?
     public var faqEnabled: Bool?
+    public var courseNotificationCount: Int?
 
     // helper attributes, if DTO does not contain complete data
     public var numberOfLectures: Int?

--- a/Sources/SharedModels/Course/CourseForDashboardDTO.swift
+++ b/Sources/SharedModels/Course/CourseForDashboardDTO.swift
@@ -16,6 +16,7 @@ public struct CourseForDashboardDTO: Codable {
     public var fileUploadScores: CourseScore?
     public var quizScores: CourseScore?
     public var participationResults: [ParticipationResultDTO]?
+    public var courseNotificationCount: Int?
 }
 
 public extension CourseForDashboardDTO {


### PR DESCRIPTION
This PR adds basic support for the new Course specific notifications:
- `CoursePushNotification`: A class to decode every type of new notification in an enum
- `NewPostNotification`: First new type of notification 
- `DisplayableNotification`: Protocol to enhance display of notifications in app