### PR TITLE
`Communication`: Show placeholder profile pics in chat list

### DIFF
--- a/Sources/DesignLibrary/ProfilePictureInitialsView.swift
+++ b/Sources/DesignLibrary/ProfilePictureInitialsView.swift
@@ -1,0 +1,53 @@
+//
+//  ProfilePictureInitialsView.swift
+//  ArtemisCore
+//
+//  Created by Anian Schleyer on 16.03.25.
+//
+
+import CryptoKit
+import SwiftUI
+
+public struct ProfilePictureInitialsView: View {
+    let name: String
+    let userId: String
+    let size: CGFloat
+
+    public init(name: String, userId: String, size: CGFloat) {
+        self.name = name
+        self.userId = userId
+        self.size = size
+    }
+
+    public var body: some View {
+        ZStack {
+            Rectangle()
+                .fill(backgroundColor)
+                .frame(width: size, height: size)
+            Text(initials)
+                .font(.system(size: 0.42 * size, weight: .bold, design: .rounded))
+                .fontDesign(.rounded)
+                .foregroundStyle(.white)
+        }
+    }
+
+    private var initials: String {
+        let nameComponents = name.split(separator: " ")
+        let initialFirstName = nameComponents.first?.prefix(1) ?? ""
+        let initialLastName = nameComponents.last?.prefix(1) ?? ""
+        let initials = initialFirstName + initialLastName
+        if initials.isEmpty {
+            return "NA"
+        } else {
+            return String(initials)
+        }
+    }
+
+    private var backgroundColor: Color {
+        // We can't use userId.hashValue because it changes between every program execution
+        var sha = SHA256()
+        sha.update(data: Data(userId.utf8))
+        let hash = abs(sha.finalize().reduce(0) { $0 << 8 | Int($1) }) % 255
+        return Color(hue: Double(hash) / 255, saturation: 0.5, brightness: 0.5)
+    }
+}

--- a/Sources/PushNotifications/PushNotificationHandler+Communication.swift
+++ b/Sources/PushNotifications/PushNotificationHandler+Communication.swift
@@ -7,6 +7,7 @@
 
 import APIClient
 import CryptoKit
+import DesignLibrary
 import Foundation
 import Intents
 import SwiftUI
@@ -72,7 +73,8 @@ public extension PushNotificationHandler {
         let baseUrl = UserSessionFactory.shared.institution?.baseURL
         guard let urlString, let url = URL(string: urlString, relativeTo: baseUrl) else {
             // Default profile picture fallback
-            let imageData = await ImageRenderer(content: DefaultProfilePic(name: user, userId: id)).uiImage?.pngData()
+            let pictureView = ProfilePictureInitialsView(name: user, userId: id, size: 100)
+            let imageData = await ImageRenderer(content: pictureView).uiImage?.pngData()
             if let imageData {
                 return INImage(imageData: imageData)
             }
@@ -95,43 +97,6 @@ public extension PushNotificationHandler {
         }
 
         return INImage(imageData: data)
-    }
-}
-
-private struct DefaultProfilePic: View {
-    let name: String
-    let userId: String
-
-    var body: some View {
-        ZStack {
-            Rectangle()
-                .fill(backgroundColor)
-                .frame(width: 100, height: 100)
-            Text(initials)
-                .font(.system(size: 42, weight: .bold, design: .rounded))
-                .fontDesign(.rounded)
-                .foregroundStyle(.white)
-        }
-    }
-
-    private var initials: String {
-        let nameComponents = name.split(separator: " ")
-        let initialFirstName = nameComponents.first?.prefix(1) ?? ""
-        let initialLastName = nameComponents.last?.prefix(1) ?? ""
-        let initials = initialFirstName + initialLastName
-        if initials.isEmpty {
-            return "NA"
-        } else {
-            return String(initials)
-        }
-    }
-
-    private var backgroundColor: Color {
-        // We can't use userId.hashValue because it changes between every program execution
-        var sha = SHA256()
-        sha.update(data: Data(userId.utf8))
-        let hash = abs(sha.finalize().reduce(0) { $0 << 8 | Int($1) }) % 255
-        return Color(hue: Double(hash) / 255, saturation: 0.5, brightness: 0.5)
     }
 }
 

--- a/Sources/SharedModels/Conversation/OneToOneChat.swift
+++ b/Sources/SharedModels/Conversation/OneToOneChat.swift
@@ -44,6 +44,11 @@ public struct OneToOneChat: BaseConversation {
                 .frame(width: 30, height: 30)
                 .clipShape(.rect(cornerRadius: .s))
             )
+        } else if let name = otherUser?.name, let id = otherUser?.id {
+            AnyView(
+                ProfilePictureInitialsView(name: name, userId: "\(id)", size: 30)
+                    .clipShape(.rect(cornerRadius: .s))
+            )
         } else {
             AnyView(Image(systemName: "lock.fill").resizable())
         }


### PR DESCRIPTION
Adds a profile picture placeholder in the conversation list for users that don't have a profile picture.

<img src="https://github.com/user-attachments/assets/044ccc12-958e-474f-81bd-c1b8d1074b99" alt="New image" width="300">