### PR TITLE
`Communication`: Add isSaved to Message and AnswerMessage

### DIFF
--- a/Sources/SharedModels/Conversation/Message/AnswerMessage.swift
+++ b/Sources/SharedModels/Conversation/Message/AnswerMessage.swift
@@ -19,6 +19,7 @@ public struct AnswerMessage: BaseMessage {
     public var resolvesPost: Bool?
     public var reactions: [Reaction]?
     public var post: Message?
+    public var isSaved: Bool?
 }
 
 public extension AnswerMessage {

--- a/Sources/SharedModels/Conversation/Message/Message.swift
+++ b/Sources/SharedModels/Conversation/Message/Message.swift
@@ -25,6 +25,7 @@ public struct Message: BaseMessage {
     public var resolved: Bool?
     public var answerCount: Int?
     public var voteCount: Int?
+    public var isSaved: Bool?
 }
 
 public extension Message {


### PR DESCRIPTION
This PR adds an additional member to Message and AnswerMessage: `isSaved`. This is needed for the "Save messages for later" feature.