### PR TITLE
`General`: Add Feature toggle property wrapper

### DIFF
--- a/Sources/ProfileInfo/FeatureAvailability/FeatureAvailability.swift
+++ b/Sources/ProfileInfo/FeatureAvailability/FeatureAvailability.swift
@@ -1,0 +1,25 @@
+//
+//  FeatureAvailability.swift
+//  ArtemisCore
+//
+//  Created by Anian Schleyer on 23.03.25.
+//
+
+import Foundation
+
+/// Property Wrapper for accessing Feature Toggle values, thus conditionally hiding Views.
+@propertyWrapper
+public struct FeatureAvailability {
+    private let feature: Feature
+    public init(_ feature: Feature) {
+        self.feature = feature
+    }
+
+    public var wrappedValue: Bool {
+        FeatureList.shared.availableFeatures.contains(feature.rawValue)
+    }
+}
+
+public enum Feature: String {
+    case courseNotifications = "CourseSpecificNotifications"
+}

--- a/Sources/ProfileInfo/FeatureAvailability/FeatureList.swift
+++ b/Sources/ProfileInfo/FeatureAvailability/FeatureList.swift
@@ -1,0 +1,41 @@
+//
+//  FeatureList.swift
+//  ArtemisCore
+//
+//  Created by Anian Schleyer on 23.03.25.
+//
+
+import Common
+import Foundation
+
+@Observable
+public class FeatureList {
+    public static let shared = FeatureList()
+
+    var availableFeatures = [String]()
+    public var compatibleVersions: PlatformVersionCompatibility?
+
+    private var lastChecked: Date = .distantPast
+
+    private init() {}
+
+    /// In case the last check was more than 60 seconds ago or failed,
+    /// perform a request to the server to check available features and supported client versions.
+    public func checkAvailability(forceCheck: Bool = false) async {
+        if lastChecked.timeIntervalSinceNow < -60 || forceCheck {
+            log.info("Checking feature list and min versions")
+            let service = ProfileInfoServiceFactory.shared
+            let info = await service.getProfileInfo()
+            switch info {
+            case .failure:
+                lastChecked = .distantPast
+            case .done(let response):
+                availableFeatures = response.features
+                compatibleVersions = response.compatibleVersions
+                lastChecked = .now
+            default:
+                break
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a property wrapper to support using Feature toggles.

Usage:
```swift
struct SomeView: View {
    @FeatureAvailability(.courseNotifications) var notificationsEnabled

    var body: some View {
        if notificationsEnabled {
            // New feature
        } else {
            // Old feature or fallback
        }
    }
}
```