### PR TITLE
`Chore`: Correct package structure

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -153,6 +153,7 @@ let package = Package(
                 "Common",
                 "CryptoSwift",
                 "DesignLibrary",
+                "SharedModels",
                 "UserStore",
                 .product(name: "RswiftLibrary", package: "R.swift")
             ],


### PR DESCRIPTION
Due to a wrong package structure there was a build failure. this PR addresses this.