### PR TITLE
`General`: Change TUM Artemis URL

### DIFF
--- a/Sources/UserStore/Config.swift
+++ b/Sources/UserStore/Config.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 enum Config {
-    static let tumBaseEndpointUrl = URL(string: "https://artemis.ase.in.tum.de/")
+    static let tumBaseEndpointUrl = URL(string: "https://artemis.tum.de/")
     static let kitBaseEndpointUrl = URL(string: "https://artemis.praktomat.cs.kit.edu/")
     static let hmBaseEndpointUrl = URL(string: "https://artemis.cs.hm.edu/")
     static let codeAbilityBaseEndpointUrl = URL(string: "https://artemis.codeability.uibk.ac.at/")

--- a/Sources/UserStore/Config.swift
+++ b/Sources/UserStore/Config.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  Config.swift
 //
 //
 //  Created by Sven Andabaka on 27.02.23.


### PR DESCRIPTION
We want to use `artemis.tum.de` for Artemis at TUM, all other urls (like the currently used `artemis.ase.in.tum.de`) will be redirected to that.