### PR TITLE
`General`: Update KIT Artemis url

### DIFF
--- a/Sources/UserStore/Config.swift
+++ b/Sources/UserStore/Config.swift
@@ -9,7 +9,7 @@ import Foundation
 
 enum Config {
     static let tumBaseEndpointUrl = URL(string: "https://artemis.tum.de/")
-    static let kitBaseEndpointUrl = URL(string: "https://artemis.praktomat.cs.kit.edu/")
+    static let kitBaseEndpointUrl = URL(string: "https://artemis.cs.kit.edu/")
     static let hmBaseEndpointUrl = URL(string: "https://artemis.cs.hm.edu/")
     static let codeAbilityBaseEndpointUrl = URL(string: "https://artemis.codeability.uibk.ac.at/")
 }


### PR DESCRIPTION
In https://github.com/ls1intum/Artemis/pull/10595, a new URL for the KIT Artemis instance is added. We update this for the iOS app as well