### PR TITLE
`Notifications`: Add DTOs for course notification types

### DIFF
--- a/Sources/PushNotifications/Models/Communication/NewAnnouncementNotification.swift
+++ b/Sources/PushNotifications/Models/Communication/NewAnnouncementNotification.swift
@@ -1,0 +1,20 @@
+//
+//  NewAnnouncementNotification.swift
+//  ArtemisCore
+//
+//  Created by Anian Schleyer on 28.03.25.
+//
+
+public struct NewAnnouncementNotification: CourseBaseNotification {
+    public var courseId: Int?
+    public var courseTitle: String?
+    public var courseIconUrl: String?
+
+    public var postId: Int?
+    public var postTitle: String?
+    public var postMarkdownContent: String?
+    public var authorName: String?
+    public var authorImageUrl: String?
+    public var authorId: Int?
+    public var channelId: Int?
+}

--- a/Sources/PushNotifications/Models/Communication/NewAnswerNotification.swift
+++ b/Sources/PushNotifications/Models/Communication/NewAnswerNotification.swift
@@ -1,0 +1,25 @@
+//
+//  NewAnswerNotification.swift
+//  ArtemisCore
+//
+//  Created by Anian Schleyer on 28.03.25.
+//
+
+public struct NewAnswerNotification: CourseBaseNotification {
+    public var courseId: Int?
+    public var courseTitle: String?
+    public var courseIconUrl: String?
+
+    public var postMarkdownContent: String?
+    public var postCreationDate: String?
+    public var postAuthorName: String?
+    public var postId: Int?
+    public var replyMarkdownContent: String?
+    public var replyCreationDate: String?
+    public var replyAuthorName: String?
+    public var replyAuthorId: Int?
+    public var replyImageUrl: String?
+    public var replyId: Int?
+    public var channelName: String?
+    public var channelId: Int?
+}

--- a/Sources/PushNotifications/Models/Communication/NewMentionNotification.swift
+++ b/Sources/PushNotifications/Models/Communication/NewMentionNotification.swift
@@ -1,0 +1,25 @@
+//
+//  NewMentionNotification.swift
+//  ArtemisCore
+//
+//  Created by Anian Schleyer on 28.03.25.
+//
+
+public struct NewMentionNotification: CourseBaseNotification {
+    public var courseId: Int?
+    public var courseTitle: String?
+    public var courseIconUrl: String?
+
+    public var postMarkdownContent: String?
+    public var postCreationDate: String?
+    public var postAuthorName: String?
+    public var postId: Int?
+    public var replyMarkdownContent: String?
+    public var replyCreationDate: String?
+    public var replyAuthorName: String?
+    public var replyAuthorId: Int?
+    public var replyImageUrl: String?
+    public var replyId: Int?
+    public var channelName: String?
+    public var channelId: Int?
+}

--- a/Sources/PushNotifications/Models/CoursePushNotification.swift
+++ b/Sources/PushNotifications/Models/CoursePushNotification.swift
@@ -19,6 +19,7 @@ public enum CoursePushNotification: Codable {
     case attachmentChanged(notification: AttachmentChangedNotification)
     case exerciseAssessed(notification: ExerciseAssessedNotification)
     case exerciseOpenForPractice(notification: ExerciseOpenForPracticeNotification)
+    case exerciseUpdated(notification: ExerciseUpdatedNotification)
     case unknown
 
     /// Initializer for using different CodingKeys.
@@ -36,6 +37,8 @@ public enum CoursePushNotification: Codable {
             self = .exerciseAssessed(notification: try decodeNotification())
         case .exerciseOpenForPracticeNotification:
             self = .exerciseOpenForPractice(notification: try decodeNotification())
+        case .exerciseUpdatedNotification:
+            self = .exerciseUpdated(notification: try decodeNotification())
         case .unknown:
             self = .unknown
         }
@@ -60,7 +63,7 @@ public enum CoursePushNotification: Codable {
 
 // Helper for making decoding above much more compact
 // by making use of compiler's automatic type derivation
-struct NotificationDecoder<Key: CodingKey> {
+private struct NotificationDecoder<Key: CodingKey> {
     let key: Key
     let container: KeyedDecodingContainer<Key>
 
@@ -74,6 +77,7 @@ public enum CourseNotificationType: String, Codable, ConstantsEnum {
     case attachmentChangedNotification
     case exerciseAssessedNotification
     case exerciseOpenForPracticeNotification
+    case exerciseUpdatedNotification
     case unknown
 }
 

--- a/Sources/PushNotifications/Models/CoursePushNotification.swift
+++ b/Sources/PushNotifications/Models/CoursePushNotification.swift
@@ -15,6 +15,7 @@ public enum CoursePushNotification: Codable {
         case parameters
     }
 
+    case newAnnouncement(notification: NewAnnouncementNotification)
     case newPost(notification: NewPostNotification)
     case attachmentChanged(notification: AttachmentChangedNotification)
     case exerciseAssessed(notification: ExerciseAssessedNotification)
@@ -28,19 +29,21 @@ public enum CoursePushNotification: Codable {
         let container = try decoder.container(keyedBy: Key.self)
         let type = try container.decode(CourseNotificationType.self, forKey: typeKey)
         let decodeNotification = NotificationDecoder(key: parametersKey, container: container)
-        switch type {
+        self = switch type {
+        case .newAnnouncementNotification:
+            .newAnnouncement(notification: try decodeNotification())
         case .newPostNotification:
-            self = .newPost(notification: try decodeNotification())
+            .newPost(notification: try decodeNotification())
         case .attachmentChangedNotification:
-            self = .attachmentChanged(notification: try decodeNotification())
+            .attachmentChanged(notification: try decodeNotification())
         case .exerciseAssessedNotification:
-            self = .exerciseAssessed(notification: try decodeNotification())
+            .exerciseAssessed(notification: try decodeNotification())
         case .exerciseOpenForPracticeNotification:
-            self = .exerciseOpenForPractice(notification: try decodeNotification())
+            .exerciseOpenForPractice(notification: try decodeNotification())
         case .exerciseUpdatedNotification:
-            self = .exerciseUpdated(notification: try decodeNotification())
+            .exerciseUpdated(notification: try decodeNotification())
         case .unknown:
-            self = .unknown
+            .unknown
         }
     }
 
@@ -73,6 +76,7 @@ private struct NotificationDecoder<Key: CodingKey> {
 }
 
 public enum CourseNotificationType: String, Codable, ConstantsEnum {
+    case newAnnouncementNotification
     case newPostNotification
     case attachmentChangedNotification
     case exerciseAssessedNotification

--- a/Sources/PushNotifications/Models/CoursePushNotification.swift
+++ b/Sources/PushNotifications/Models/CoursePushNotification.swift
@@ -17,6 +17,7 @@ public enum CoursePushNotification: Codable {
 
     case newPost(notification: NewPostNotification)
     case attachmentChanged(notification: AttachmentChangedNotification)
+    case exerciseAssessed(notification: ExerciseAssessedNotification)
     case unknown
 
     /// Initializer for using different CodingKeys.
@@ -30,6 +31,8 @@ public enum CoursePushNotification: Codable {
             self = .newPost(notification: try decodeNotification())
         case .attachmentChangedNotification:
             self = .attachmentChanged(notification: try decodeNotification())
+        case .exerciseAssessedNotification:
+            self = .exerciseAssessed(notification: try decodeNotification())
         case .unknown:
             self = .unknown
         }
@@ -66,6 +69,7 @@ struct NotificationDecoder<Key: CodingKey> {
 public enum CourseNotificationType: String, Codable, ConstantsEnum {
     case newPostNotification
     case attachmentChangedNotification
+    case exerciseAssessedNotification
     case unknown
 }
 

--- a/Sources/PushNotifications/Models/CoursePushNotification.swift
+++ b/Sources/PushNotifications/Models/CoursePushNotification.swift
@@ -18,6 +18,7 @@ public enum CoursePushNotification: Codable {
     case newPost(notification: NewPostNotification)
     case attachmentChanged(notification: AttachmentChangedNotification)
     case exerciseAssessed(notification: ExerciseAssessedNotification)
+    case exerciseOpenForPractice(notification: ExerciseOpenForPracticeNotification)
     case unknown
 
     /// Initializer for using different CodingKeys.
@@ -33,6 +34,8 @@ public enum CoursePushNotification: Codable {
             self = .attachmentChanged(notification: try decodeNotification())
         case .exerciseAssessedNotification:
             self = .exerciseAssessed(notification: try decodeNotification())
+        case .exerciseOpenForPracticeNotification:
+            self = .exerciseOpenForPractice(notification: try decodeNotification())
         case .unknown:
             self = .unknown
         }
@@ -70,6 +73,7 @@ public enum CourseNotificationType: String, Codable, ConstantsEnum {
     case newPostNotification
     case attachmentChangedNotification
     case exerciseAssessedNotification
+    case exerciseOpenForPracticeNotification
     case unknown
 }
 

--- a/Sources/PushNotifications/Models/CoursePushNotification.swift
+++ b/Sources/PushNotifications/Models/CoursePushNotification.swift
@@ -15,14 +15,15 @@ public enum CoursePushNotification: Codable {
         case parameters
     }
 
-    case newAnnouncement(notification: NewAnnouncementNotification)
-    case newAnswer(notification: NewAnswerNotification)
-    case newPost(notification: NewPostNotification)
-    case attachmentChanged(notification: AttachmentChangedNotification)
-    case exerciseAssessed(notification: ExerciseAssessedNotification)
-    case exerciseOpenForPractice(notification: ExerciseOpenForPracticeNotification)
-    case exerciseUpdated(notification: ExerciseUpdatedNotification)
-    case newExercise(notification: NewExerciseNotification)
+    case newAnnouncement(NewAnnouncementNotification)
+    case newAnswer(NewAnswerNotification)
+    case newPost(NewPostNotification)
+    case attachmentChanged(AttachmentChangedNotification)
+    case exerciseAssessed(ExerciseAssessedNotification)
+    case exerciseOpenForPractice(ExerciseOpenForPracticeNotification)
+    case exerciseUpdated(ExerciseUpdatedNotification)
+    case newExercise(NewExerciseNotification)
+    case newManualFeedbackRequest(NewManualFeedbackRequestNotification)
     case unknown
 
     /// Initializer for using different CodingKeys.
@@ -32,24 +33,18 @@ public enum CoursePushNotification: Codable {
         let type = try container.decode(CourseNotificationType.self, forKey: typeKey)
         let decodeNotification = NotificationDecoder(key: parametersKey, container: container)
         self = switch type {
-        case .newAnnouncementNotification:
-            .newAnnouncement(notification: try decodeNotification())
-        case .newAnswerNotification:
-            .newAnswer(notification: try decodeNotification())
-        case .newPostNotification:
-            .newPost(notification: try decodeNotification())
-        case .attachmentChangedNotification:
-            .attachmentChanged(notification: try decodeNotification())
-        case .exerciseAssessedNotification:
-            .exerciseAssessed(notification: try decodeNotification())
-        case .exerciseOpenForPracticeNotification:
-            .exerciseOpenForPractice(notification: try decodeNotification())
-        case .exerciseUpdatedNotification:
-            .exerciseUpdated(notification: try decodeNotification())
-        case .newExerciseNotification:
-            .newExercise(notification: try decodeNotification())
-        case .unknown:
-            .unknown
+        // Communication
+        case .newAnnouncementNotification: .newAnnouncement(try decodeNotification())
+        case .newAnswerNotification: .newAnswer(try decodeNotification())
+        case .newPostNotification: .newPost(try decodeNotification())
+        // General
+        case .attachmentChangedNotification: .attachmentChanged(try decodeNotification())
+        case .exerciseAssessedNotification: .exerciseAssessed(try decodeNotification())
+        case .exerciseOpenForPracticeNotification: .exerciseOpenForPractice(try decodeNotification())
+        case .exerciseUpdatedNotification: .exerciseUpdated(try decodeNotification())
+        case .newExerciseNotification: .newExercise(try decodeNotification())
+        case .newManualFeedbackRequestNotification: .newManualFeedbackRequest(try decodeNotification())
+        case .unknown: .unknown
         }
     }
 
@@ -90,6 +85,7 @@ public enum CourseNotificationType: String, Codable, ConstantsEnum {
     case exerciseOpenForPracticeNotification
     case exerciseUpdatedNotification
     case newExerciseNotification
+    case newManualFeedbackRequestNotification
     case unknown
 }
 

--- a/Sources/PushNotifications/Models/CoursePushNotification.swift
+++ b/Sources/PushNotifications/Models/CoursePushNotification.swift
@@ -17,6 +17,7 @@ public enum CoursePushNotification: Codable {
 
     case newAnnouncement(NewAnnouncementNotification)
     case newAnswer(NewAnswerNotification)
+    case newMention(NewMentionNotification)
     case newPost(NewPostNotification)
     case attachmentChanged(AttachmentChangedNotification)
     case exerciseAssessed(ExerciseAssessedNotification)
@@ -36,6 +37,7 @@ public enum CoursePushNotification: Codable {
         // Communication
         case .newAnnouncementNotification: .newAnnouncement(try decodeNotification())
         case .newAnswerNotification: .newAnswer(try decodeNotification())
+        case .newMentionNotification: .newMention(try decodeNotification())
         case .newPostNotification: .newPost(try decodeNotification())
         // General
         case .attachmentChangedNotification: .attachmentChanged(try decodeNotification())
@@ -77,9 +79,12 @@ private struct NotificationDecoder<Key: CodingKey> {
 }
 
 public enum CourseNotificationType: String, Codable, ConstantsEnum {
+    // Communication
     case newAnnouncementNotification
     case newAnswerNotification
+    case newMentionNotification
     case newPostNotification
+    // General
     case attachmentChangedNotification
     case exerciseAssessedNotification
     case exerciseOpenForPracticeNotification

--- a/Sources/PushNotifications/Models/CoursePushNotification.swift
+++ b/Sources/PushNotifications/Models/CoursePushNotification.swift
@@ -22,6 +22,7 @@ public enum CoursePushNotification: Codable {
     case exerciseAssessed(notification: ExerciseAssessedNotification)
     case exerciseOpenForPractice(notification: ExerciseOpenForPracticeNotification)
     case exerciseUpdated(notification: ExerciseUpdatedNotification)
+    case newExercise(notification: NewExerciseNotification)
     case unknown
 
     /// Initializer for using different CodingKeys.
@@ -45,6 +46,8 @@ public enum CoursePushNotification: Codable {
             .exerciseOpenForPractice(notification: try decodeNotification())
         case .exerciseUpdatedNotification:
             .exerciseUpdated(notification: try decodeNotification())
+        case .newExerciseNotification:
+            .newExercise(notification: try decodeNotification())
         case .unknown:
             .unknown
         }
@@ -86,6 +89,7 @@ public enum CourseNotificationType: String, Codable, ConstantsEnum {
     case exerciseAssessedNotification
     case exerciseOpenForPracticeNotification
     case exerciseUpdatedNotification
+    case newExerciseNotification
     case unknown
 }
 

--- a/Sources/PushNotifications/Models/CoursePushNotification.swift
+++ b/Sources/PushNotifications/Models/CoursePushNotification.swift
@@ -16,6 +16,7 @@ public enum CoursePushNotification: Codable {
     }
 
     case newAnnouncement(notification: NewAnnouncementNotification)
+    case newAnswer(notification: NewAnswerNotification)
     case newPost(notification: NewPostNotification)
     case attachmentChanged(notification: AttachmentChangedNotification)
     case exerciseAssessed(notification: ExerciseAssessedNotification)
@@ -32,6 +33,8 @@ public enum CoursePushNotification: Codable {
         self = switch type {
         case .newAnnouncementNotification:
             .newAnnouncement(notification: try decodeNotification())
+        case .newAnswerNotification:
+            .newAnswer(notification: try decodeNotification())
         case .newPostNotification:
             .newPost(notification: try decodeNotification())
         case .attachmentChangedNotification:
@@ -77,6 +80,7 @@ private struct NotificationDecoder<Key: CodingKey> {
 
 public enum CourseNotificationType: String, Codable, ConstantsEnum {
     case newAnnouncementNotification
+    case newAnswerNotification
     case newPostNotification
     case attachmentChangedNotification
     case exerciseAssessedNotification

--- a/Sources/PushNotifications/Models/CoursePushNotification.swift
+++ b/Sources/PushNotifications/Models/CoursePushNotification.swift
@@ -25,6 +25,7 @@ public enum CoursePushNotification: Codable {
     case exerciseUpdated(ExerciseUpdatedNotification)
     case newExercise(NewExerciseNotification)
     case newManualFeedbackRequest(NewManualFeedbackRequestNotification)
+    case quizStarted(QuizExerciseStartedNotification)
     case unknown
 
     /// Initializer for using different CodingKeys.
@@ -46,6 +47,7 @@ public enum CoursePushNotification: Codable {
         case .exerciseUpdatedNotification: .exerciseUpdated(try decodeNotification())
         case .newExerciseNotification: .newExercise(try decodeNotification())
         case .newManualFeedbackRequestNotification: .newManualFeedbackRequest(try decodeNotification())
+        case .quizExerciseStartedNotification: .quizStarted(try decodeNotification())
         case .unknown: .unknown
         }
     }
@@ -91,6 +93,7 @@ public enum CourseNotificationType: String, Codable, ConstantsEnum {
     case exerciseUpdatedNotification
     case newExerciseNotification
     case newManualFeedbackRequestNotification
+    case quizExerciseStartedNotification
     case unknown
 }
 

--- a/Sources/PushNotifications/Models/General/AttachmentChangedNotification.swift
+++ b/Sources/PushNotifications/Models/General/AttachmentChangedNotification.swift
@@ -1,0 +1,17 @@
+//
+//  AttachmentChangedNotification.swift
+//  ArtemisCore
+//
+//  Created by Anian Schleyer on 28.03.25.
+//
+
+public struct AttachmentChangedNotification: CourseBaseNotification {
+    public var courseId: Int?
+    public var courseTitle: String?
+    public var courseIconUrl: String?
+
+    public var attachmentName: String?
+    public var exerciseOrLectureName: String?
+    public var exerciseId: Int?
+    public var lectureId: Int?
+}

--- a/Sources/PushNotifications/Models/General/ExerciseAssessedNotification.swift
+++ b/Sources/PushNotifications/Models/General/ExerciseAssessedNotification.swift
@@ -1,0 +1,18 @@
+//
+//  ExerciseAssessedNotification.swift
+//  ArtemisCore
+//
+//  Created by Anian Schleyer on 28.03.25.
+//
+
+public struct ExerciseAssessedNotification: CourseBaseNotification {
+    public var courseId: Int?
+    public var courseTitle: String?
+    public var courseIconUrl: String?
+
+    public var exerciseId: Int?
+    public var exerciseTitle: String?
+    public var exerciseType: String?
+    public var numberOfPoints: Int?
+    public var score: Int?
+}

--- a/Sources/PushNotifications/Models/General/ExerciseOpenForPracticeNotification.swift
+++ b/Sources/PushNotifications/Models/General/ExerciseOpenForPracticeNotification.swift
@@ -1,0 +1,15 @@
+//
+//  ExerciseOpenForPracticeNotification.swift
+//  ArtemisCore
+//
+//  Created by Anian Schleyer on 28.03.25.
+//
+
+public struct ExerciseOpenForPracticeNotification: CourseBaseNotification {
+    public var courseId: Int?
+    public var courseTitle: String?
+    public var courseIconUrl: String?
+
+    public var exerciseId: Int?
+    public var exerciseTitle: String?
+}

--- a/Sources/PushNotifications/Models/General/ExerciseUpdatedNotification.swift
+++ b/Sources/PushNotifications/Models/General/ExerciseUpdatedNotification.swift
@@ -1,0 +1,15 @@
+//
+//  ExerciseUpdatedNotification.swift
+//  ArtemisCore
+//
+//  Created by Anian Schleyer on 28.03.25.
+//
+
+public struct ExerciseUpdatedNotification: CourseBaseNotification {
+    public var courseId: Int?
+    public var courseTitle: String?
+    public var courseIconUrl: String?
+
+    public var exerciseId: Int?
+    public var exerciseTitle: String?
+}

--- a/Sources/PushNotifications/Models/General/NewExerciseNotification.swift
+++ b/Sources/PushNotifications/Models/General/NewExerciseNotification.swift
@@ -1,0 +1,19 @@
+//
+//  NewExerciseNotification.swift
+//  ArtemisCore
+//
+//  Created by Anian Schleyer on 28.03.25.
+//
+
+public struct NewExerciseNotification: CourseBaseNotification {
+    public var courseId: Int?
+    public var courseTitle: String?
+    public var courseIconUrl: String?
+
+    public var exerciseId: Int?
+    public var exerciseTitle: String?
+    public var difficulty: String?
+    public var releaseDate: String?
+    public var dueDate: String?
+    public var numberOfPoints: Int?
+}

--- a/Sources/PushNotifications/Models/General/NewManualFeedbackRequestNotification.swift
+++ b/Sources/PushNotifications/Models/General/NewManualFeedbackRequestNotification.swift
@@ -1,0 +1,15 @@
+//
+//  NewManualFeedbackRequestNotification.swift
+//  ArtemisCore
+//
+//  Created by Anian Schleyer on 28.03.25.
+//
+
+public struct NewManualFeedbackRequestNotification: CourseBaseNotification {
+    public var courseId: Int?
+    public var courseTitle: String?
+    public var courseIconUrl: String?
+
+    public var exerciseId: Int?
+    public var exerciseTitle: String?
+}

--- a/Sources/PushNotifications/Models/General/QuizExerciseStartedNotification.swift
+++ b/Sources/PushNotifications/Models/General/QuizExerciseStartedNotification.swift
@@ -1,0 +1,15 @@
+//
+//  QuizExerciseStartedNotification.swift
+//  ArtemisCore
+//
+//  Created by Anian Schleyer on 28.03.25.
+//
+
+public struct QuizExerciseStartedNotification: CourseBaseNotification {
+    public var courseId: Int?
+    public var courseTitle: String?
+    public var courseIconUrl: String?
+
+    public var exerciseId: Int?
+    public var exerciseTitle: String?
+}


### PR DESCRIPTION
This PR adds the same DTOs from https://github.com/ls1intum/Artemis/pull/10597 so that we can decode all available notification types on iOS.