### PR TITLE
`Dashboard`: Add file path prefix to course icons

### DIFF
--- a/Sources/SharedModels/Course/Course.swift
+++ b/Sources/SharedModels/Course/Course.swift
@@ -32,7 +32,8 @@ public struct Course: Codable, Identifiable {
 
     public var courseIconURL: URL? {
         guard let courseIcon else { return nil }
-        return URL(string: courseIcon, relativeTo: UserSessionFactory.shared.institution?.baseURL)
+        let baseUrl = UserSessionFactory.shared.institution?.baseURL?.appending(path: "api/core/files")
+        return baseUrl?.appending(path: courseIcon)
     }
 
     public var courseColor: Color {


### PR DESCRIPTION
Course icons need an `/api/core/files` prefix with Artemis version 8.0, this adds it