### PR TITLE
`Login`: Revert LoginService API to old version

### DIFF
--- a/Sources/Login/Services/LoginService/LoginServiceImpl.swift
+++ b/Sources/Login/Services/LoginService/LoginServiceImpl.swift
@@ -27,7 +27,7 @@ class LoginServiceImpl: LoginService {
         }
 
         var resourceName: String {
-            return "api/core/public/authenticate"
+            return "api/public/authenticate"
         }
     }
 

--- a/Sources/SharedServices/AccountService/AccountServiceImpl.swift
+++ b/Sources/SharedServices/AccountService/AccountServiceImpl.swift
@@ -22,7 +22,7 @@ struct AccountServiceImpl: AccountService {
         }
 
         var resourceName: String {
-            return "api/core/public/account"
+            return "api/public/account"
         }
     }
 


### PR DESCRIPTION
For Artemis Exam Checker we need a new version of Core Modules, which is still compatible with Artemis Servers below version 8.0. Thus, we temporarily need a Core Modules version with the old login endpoint