### PR TITLE
`Communication`: Fix profile pictures not loading

### DIFF
--- a/Sources/PushNotifications/PushNotificationHandler+Communication.swift
+++ b/Sources/PushNotifications/PushNotificationHandler+Communication.swift
@@ -70,7 +70,7 @@ public extension PushNotificationHandler {
     private static func getUserImage(for user: String,
                                      with id: String,
                                      from urlString: String?) async throws -> INImage? {
-        let baseUrl = UserSessionFactory.shared.institution?.baseURL?.appending(path: "/api/core/files")
+        let baseUrl = UserSessionFactory.shared.institution?.baseURL?.appending(path: "api/core/files")
         guard let urlString, let url = URL(string: urlString, relativeTo: baseUrl) else {
             // Default profile picture fallback
             let pictureView = ProfilePictureInitialsView(name: user, userId: id, size: 100)

--- a/Sources/SharedModels/Conversation/ConversationUser.swift
+++ b/Sources/SharedModels/Conversation/ConversationUser.swift
@@ -26,7 +26,7 @@ public struct ConversationUser: UserPublicInfo {
     public var imagePath: URL? {
         guard let imageUrl else { return nil }
         return UserSessionFactory.shared.institution?.baseURL?
-            .appending(path: "/api/core/files")
+            .appending(path: "api/core/files")
             .appending(path: imageUrl)
     }
 }

--- a/Sources/SharedModels/User/Account.swift
+++ b/Sources/SharedModels/User/Account.swift
@@ -40,7 +40,7 @@ public struct Account: Codable {
     public var imagePath: URL? {
         guard let imageUrl else { return nil }
         return UserSessionFactory.shared.institution?.baseURL?
-            .appending(path: "/api/core/files")
+            .appending(path: "api/core/files")
             .appending(path: imageUrl)
     }
 }


### PR DESCRIPTION
Profile pictures could not be loaded in some cases due to double "/" in file path