### PR TITLE
`Exercises`: Add computed property for status

### DIFF
--- a/Sources/SharedModels/Exercise/BaseExercise.swift
+++ b/Sources/SharedModels/Exercise/BaseExercise.swift
@@ -292,6 +292,37 @@ private struct CategoryImpl: Codable {
     let color: String
 }
 
+extension Exercise {
+    var status: String {
+        let teamId = baseExercise.studentAssignedTeamId
+        let teamOk = !(baseExercise.teamMode ?? false)
+        || !(baseExercise.studentAssignedTeamIdComputed ?? false)
+        || teamId != nil
+
+        let participation = getSpecificStudentParticipation(testRun: false)
+
+        let uninitialized  = (baseExercise.dueDate ?? .tomorrow) > .now && participation == nil
+        let missedDueDate  = (baseExercise.dueDate ?? .tomorrow) < .now && participation == nil
+
+        if !teamOk {
+            return R.string.localizable.userNotAssignedToTeamShort()
+        } else if uninitialized {
+            return R.string.localizable.notYetStarted()
+        } else if missedDueDate {
+            return R.string.localizable.exerciseMissedDeadlineShort()
+        } else if participation?.initializationState == .finished {
+            return R.string.localizable.userSubmittedShort()
+        } else if participation?.initializationState == .initialized,
+                  case .quiz = self {
+            return R.string.localizable.userParticipatingShort()
+        } else if case .quiz(let quiz) = self, quiz.notStarted {
+            return R.string.localizable.notYetStarted()
+        } else {
+            return "–"
+        }
+    }
+}
+
 extension Exercise: Hashable {
     public static func == (lhs: Exercise, rhs: Exercise) -> Bool {
         lhs.id == rhs.id

--- a/Sources/SharedModels/Resources/en.lproj/Localizable.strings
+++ b/Sources/SharedModels/Resources/en.lproj/Localizable.strings
@@ -11,6 +11,13 @@
 "assessmentType_semiAutomatic" = "semi-automatic";
 "assessmentType_manual" = "manual";
 
+"userNotAssignedToTeamShort" = "No team yet";
+"exerciseMissedDeadlineShort" = "Missed due date";
+"notYetStarted" = "Not yet started";
+"userNotParticipatedShort" = "Not participated";
+"userParticipatingShort" = "Currently participating";
+"userSubmittedShort" = "Already submitted";
+
 // MARK: Conversation
 "archived" = "(Archived)";
 "onlyYou" = "Only you";


### PR DESCRIPTION
This PR extends the exercise with status for [exercise chips PR](https://github.com/ls1intum/artemis-ios/pull/333).