### PR TITLE
`Login`: Remove duplicate passkey functions

### DIFF
--- a/Sources/Login/Services/LoginService/LoginService.swift
+++ b/Sources/Login/Services/LoginService/LoginService.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  LoginService.swift
 //
 //
 //  Created by Sven Andabaka on 09.01.23.
@@ -23,16 +23,6 @@ public protocol LoginService {
      * Perform a login request with a signed passkey challenge.
      */
     func loginWithPasskey(authenticatorData: String, clientDataJSON: String, signature: String, userHandle: String, credentialId: String) async -> NetworkResponse
-
-    /**
-     * Perform a request to the server to obtain a registration challenge for passkeys.
-     */
-    func getPasskeyRegistrationChallenge() async -> Result<PasskeyRegistrationChallenge, UserFacingError>
-
-    /**
-     * Perform a request to the server to register a passkey.
-     */
-    func registerPasskey(credential: PasskeyCredential) async -> NetworkResponse
 }
 
 enum LoginServiceFactory {

--- a/Sources/Login/Services/LoginService/LoginServiceImpl.swift
+++ b/Sources/Login/Services/LoginService/LoginServiceImpl.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  LoginServiceImpl.swift
 //
 //
 //  Created by Sven Andabaka on 09.01.23.
@@ -131,55 +131,6 @@ class LoginServiceImpl: LoginService {
             UserSessionFactory.shared.saveToken(jwt?.value)
             UserSessionFactory.shared.saveUsername(username: userHandle)
             UserSessionFactory.shared.setUserLoggedIn(isLoggedIn: true)
-            return .success
-        case .failure(let error):
-            return .failure(error: error)
-        }
-    }
-
-    struct RegistrationChallengeRequest: APIRequest {
-        typealias Response = PasskeyRegistrationChallenge
-
-        var resourceName: String {
-            "webauthn/register/options"
-        }
-
-        var method: HTTPMethod { .post }
-    }
-
-    func getPasskeyRegistrationChallenge() async -> Result<PasskeyRegistrationChallenge, UserFacingError> {
-        let data = await client.sendRequest(RegistrationChallengeRequest())
-        switch data {
-        case .success((let response, _)):
-            return .success(response)
-        case .failure(let error):
-            return .failure(.init(error: error))
-        }
-    }
-
-    struct RegisterRequest: APIRequest {
-        typealias Response = RawResponse
-
-        var resourceName: String {
-            "webauthn/register"
-        }
-
-        var method: HTTPMethod { .post }
-
-        let publicKey: PublicKey
-    }
-
-    struct PublicKey: Codable {
-        let credential: PasskeyCredential
-        let label: String
-    }
-
-    func registerPasskey(credential: PasskeyCredential) async -> NetworkResponse {
-        let publicKey = PublicKey(credential: credential, label: "Passkey iOS")
-        let request = RegisterRequest(publicKey: publicKey)
-        let response = await client.sendRequest(request)
-        switch response {
-        case .success((let response, _)):
             return .success
         case .failure(let error):
             return .failure(error: error)


### PR DESCRIPTION
Some passkey functions were duplicated, looks like I forgot to remove them when switching branches