### PR TITLE
`Notifications`: Fix target for mention notifications

### DIFF
--- a/Sources/PushNotifications/PushNotificationResponseHandler.swift
+++ b/Sources/PushNotifications/PushNotificationResponseHandler.swift
@@ -50,7 +50,8 @@ public class PushNotificationResponseHandler {
         case .quizExerciseStarted:
             guard let target = try? decoder.decode(QuizExerciseStartedTarget.self, from: targetData) else { return nil }
             return "courses/\(target.course)/quiz-exercises/\(target.id)/live"
-        case .newReplyForCoursePost, .newCoursePost, .newAnnouncementPost,
+        case .newReplyForCoursePost, .newCoursePost,
+                .newAnnouncementPost, .conversationUserMentioned,
                 .newExercisePost, .newReplyForExercisePost,
                 .newLecturePost, .newReplyForLecturePost,
                 .newExamPost, .newReplyForExamPost:


### PR DESCRIPTION
Tapping on a notification for User Mentions did not navigate to the corresponding conversation due to the target not being decoded correctly.

fixes https://github.com/ls1intum/Artemis/issues/10995