### PR TITLE
`Notifications`: Fix message thread navigation

### DIFF
--- a/Sources/PushNotifications/Models/Communication/NewAnswerNotification.swift
+++ b/Sources/PushNotifications/Models/Communication/NewAnswerNotification.swift
@@ -40,6 +40,6 @@ extension NewAnswerNotification: DisplayableNotification {
 
 extension NewAnswerNotification: NavigatableNotification {
     public var relativePath: String? {
-        communicationPath(courseId: courseId, conversationId: channelId, threadId: replyId)
+        communicationPath(courseId: courseId, conversationId: channelId, threadId: postId, conversationName: channelName ?? "Conversation")
     }
 }

--- a/Sources/PushNotifications/Models/NavigatableNotification.swift
+++ b/Sources/PushNotifications/Models/NavigatableNotification.swift
@@ -10,11 +10,14 @@ public protocol NavigatableNotification {
 }
 
 extension NavigatableNotification {
-    func communicationPath(courseId: Int?, conversationId: Int?, threadId: Int? = nil) -> String? {
+    func communicationPath(courseId: Int?, conversationId: Int?, threadId: Int? = nil, conversationName: String? = nil) -> String? {
         guard let courseId, let conversationId else { return nil }
         var path = "courses/\(courseId)/communication?conversationId=\(conversationId)"
         if let threadId {
             path += "&focusPostId=\(threadId)"
+        }
+        if let conversationName {
+            path += "&conversationName=\(conversationName.replacing(" ", with: ""))"
         }
         return path
     }


### PR DESCRIPTION
Message thread paths included the wrong post id and needed a name