### PR TITLE
`Notifications`: Fix exercise notification deep link

### DIFF
--- a/Sources/PushNotifications/Models/NavigatableNotification.swift
+++ b/Sources/PushNotifications/Models/NavigatableNotification.swift
@@ -24,7 +24,7 @@ extension NavigatableNotification {
 
     func exercisePath(courseId: Int?, exerciseId: Int?) -> String? {
         guard let courseId else { return nil }
-        var path = "courses/35/exercises"
+        var path = "courses/\(courseId)/exercises"
         guard let exerciseId else { return path }
         path += "/\(exerciseId)"
         return path


### PR DESCRIPTION
I accidentally left a hardcoded value in the link for exercise notifications, this PR fixes it