### PR TITLE
`Notifications`: Make isReply property of NotificationInfo accessible

### DIFF
--- a/Sources/PushNotifications/Models/PushNotification+Communication.swift
+++ b/Sources/PushNotifications/Models/PushNotification+Communication.swift
@@ -71,7 +71,7 @@ public struct PushNotificationCommunicationInfo: Codable {
     public let messageId: Int
     let profilePicUrl: String?
     let messageContent: String
-    let isReply: Bool
+    public let isReply: Bool
 }
 
 public extension PushNotificationCommunicationInfo {


### PR DESCRIPTION
We need to access isReply in oder to save posts correctly with the notification quick actions