### PR TITLE
`Notifications`: Add descriptions for settings types

### DIFF
--- a/Sources/PushNotifications/Models/NotificationSettings.swift
+++ b/Sources/PushNotifications/Models/NotificationSettings.swift
@@ -83,4 +83,39 @@ extension CourseNotificationType {
             ""
         }
     }
+
+    var settingsSubtitle: String? {
+        switch self {
+        case .addedToChannelNotification:
+            R.string.localizable.addChannelSettingsSubtitle()
+        case .channelDeletedNotification:
+            R.string.localizable.deleteChannelSettingsSubtitle()
+        case .newAnswerNotification:
+            R.string.localizable.newReplySettingsSubtitle()
+        case .newMentionNotification:
+            R.string.localizable.newMentionSettingsSubtitle()
+        case .newPostNotification:
+            R.string.localizable.newMessageSettingsSubtitle()
+        case .removedFromChannelNotification:
+            R.string.localizable.removeChannelSettingsSubtitle()
+        case .attachmentChangedNotification:
+            R.string.localizable.attachmentChangedSettingsSubtitle()
+        case .deregisteredFromTutorialGroupNotification:
+            R.string.localizable.tutorialDeregisteredSettingsSubtitle()
+        case .duplicateTestCaseNotification:
+            R.string.localizable.duplicateTestSettingsSubtitle()
+        case .newExerciseNotification:
+            R.string.localizable.exerciseReleasedSettingsSubtitle()
+        case .newManualFeedbackRequestNotification:
+            R.string.localizable.feedbackRequestSettingsSubtitle()
+        case .registeredToTutorialGroupNotification:
+            R.string.localizable.tutorialRegisteredSettingsSubtitle()
+        case .tutorialGroupAssignedNotification:
+            R.string.localizable.tutorialAssignedSettingsSubtitle()
+        case .tutorialGroupUnassignedNotification:
+            R.string.localizable.tutorialUnassignedSettingsSubtitle()
+        default:
+            nil
+        }
+    }
 }

--- a/Sources/PushNotifications/Resources/en.lproj/Localizable.strings
+++ b/Sources/PushNotifications/Resources/en.lproj/Localizable.strings
@@ -35,6 +35,25 @@
 "tutorialDeregisteredSettingsName" = "Tutorial deregistration";
 "tutorialUnassignedSettingsName" = "Tutorial unassigned";
 
+// MARK: Settings subtitles
+"newMessageSettingsSubtitle" = "Someone sent a message into a conversation that you are a part of.";
+"newReplySettingsSubtitle" = "Someone replied in a thread you created or participated in.";
+"newMentionSettingsSubtitle" = "Someone @mentioned you in a message";
+
+"exerciseReleasedSettingsSubtitle" = "A new exercise was released.";
+"attachmentChangedSettingsSubtitle" = "An attachement of a lecture or exercise has changed.";
+"feedbackRequestSettingsSubtitle" = "Feedback about an assessment was requested.";
+"duplicateTestSettingsSubtitle" = "Warning about duplicate test cases of an exercise.";
+
+"deleteChannelSettingsSubtitle" = "Someone deleted a channel that you were a part of.";
+"addChannelSettingsSubtitle" = "Someone added you to a chennel.";
+"removeChannelSettingsSubtitle" = "Someone removed you from a channel.";
+
+"tutorialAssignedSettingsSubtitle" = "You were assigned to hold a tutorial.";
+"tutorialRegisteredSettingsSubtitle" = "You were registered to participate in a tutorial group.";
+"tutorialDeregisteredSettingsSubtitle" = "You were deregistered from a tutorial group.";
+"tutorialUnassignedSettingsSubtitle" = "You were unassigned from holding a tutorial.";
+
 // MARK: Settings presets
 "settingsPresetCustom" = "Custom";
 "settingsPresetAllActivity" = "All activity";

--- a/Sources/PushNotifications/Views/NotificationSettingsView.swift
+++ b/Sources/PushNotifications/Views/NotificationSettingsView.swift
@@ -116,9 +116,11 @@ struct NotificationSettingView: View {
     var body: some View {
         if let setting = self.setting[.push] {
             Toggle(isOn: binding) {
-                // TODO: Add example or description
                 Text(settingType.settingsTitle)
                     .font(.headline)
+                if let subtitle = settingType.settingsSubtitle {
+                    Text(subtitle)
+                }
             }
         }
     }


### PR DESCRIPTION
For notification settings that might not be super clear, we add a subtitle to clear up any confusion.

<img width="300" src="https://github.com/user-attachments/assets/d8193626-8f63-4884-987b-89279d453fa4" />
