### PR TITLE
`Login`: Add recommendation screen for passkeys

### DIFF
--- a/Sources/Account/Resources/en.lproj/Localizable.strings
+++ b/Sources/Account/Resources/en.lproj/Localizable.strings
@@ -10,10 +10,16 @@
 "joinedLabel" = "Joined Artemis on";
 "accountInformationNavigationTitle" = "Account Information";
 "changeProfilePicture" = "Your profile picture can be changed in Profile Settings on the web.";
-"passkeys" = "Passkeys";
-"noPasskeys" = "No passkeys";
-"noPasskeysDescription" = "You have not registered any passkeys to your account yet.";
 
 // MARK: General
 "close" = "Close";
 "loading" = "Loading...";
+"notNow" = "Not now";
+
+// MARK: Passkeys
+"passkeyRecommendationTitle" = "Stay secure with Passkeys";
+"passkeyRecommendationBody" = "Passkeys are a good way to improve your account's security. Your device securely creates and stores a key to log in to your Artemis account.\n\nUnlike a password, passkeys can not be easily guessed or stolen using social engineering attacks.";
+"setUpPasskeys" = "Set up passkeys";
+"passkeys" = "Passkeys";
+"noPasskeys" = "No passkeys";
+"noPasskeysDescription" = "You have not registered any passkeys to your account yet.";

--- a/Sources/Account/ViewModels/AccountNavigationBarMenuViewModel.swift
+++ b/Sources/Account/ViewModels/AccountNavigationBarMenuViewModel.swift
@@ -20,6 +20,9 @@ class AccountNavigationBarMenuViewModel: ObservableObject {
     @Published var error: UserFacingError?
     @Published var isLoading = false
 
+    @Published var recommendPasskey = false
+    @Published var showPasskeySettings = false
+
     init() {
         getAccount()
     }
@@ -31,6 +34,21 @@ class AccountNavigationBarMenuViewModel: ObservableObject {
         } else {
             account = .loading
         }
+    }
+
+    func checkPasskeyRecommendation() async {
+//        if UserSessionFactory.shared.didLogInWithPassword && !recommendPasskey {
+            if let passkeys = await PasskeyServiceFactory.shared.getPasskeys().value,
+               passkeys.isEmpty {
+                // User logged in with password, but has no passkeys
+                DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                    // We need a delay, otherwise the sheet gets dismissed because
+                    // the view might get reconstructed during presentation (I guess ?)
+                    self.recommendPasskey = true
+                }
+            }
+            UserSessionFactory.shared.didLogInWithPassword = false
+//        }
     }
 
     func logout() {

--- a/Sources/Account/ViewModels/AccountNavigationBarMenuViewModel.swift
+++ b/Sources/Account/ViewModels/AccountNavigationBarMenuViewModel.swift
@@ -48,8 +48,8 @@ class AccountNavigationBarMenuViewModel {
                        passkeys.isEmpty {
                         recommendPasskey = true
                     }
+                    UserSessionFactory.shared.didLogInWithPassword = false
                 }
-                UserSessionFactory.shared.didLogInWithPassword = false
             }
         }
     }

--- a/Sources/Account/ViewModels/AccountNavigationBarMenuViewModel.swift
+++ b/Sources/Account/ViewModels/AccountNavigationBarMenuViewModel.swift
@@ -21,7 +21,6 @@ class AccountNavigationBarMenuViewModel: ObservableObject {
     @Published var isLoading = false
 
     @Published var recommendPasskey = false
-    @Published var showPasskeySettings = false
 
     init() {
         getAccount()
@@ -37,18 +36,18 @@ class AccountNavigationBarMenuViewModel: ObservableObject {
     }
 
     func checkPasskeyRecommendation() async {
-//        if UserSessionFactory.shared.didLogInWithPassword && !recommendPasskey {
+        if UserSessionFactory.shared.didLogInWithPassword && !recommendPasskey {
             if let passkeys = await PasskeyServiceFactory.shared.getPasskeys().value,
                passkeys.isEmpty {
                 // User logged in with password, but has no passkeys
-                DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
                     // We need a delay, otherwise the sheet gets dismissed because
                     // the view might get reconstructed during presentation (I guess ?)
                     self.recommendPasskey = true
                 }
             }
             UserSessionFactory.shared.didLogInWithPassword = false
-//        }
+        }
     }
 
     func logout() {

--- a/Sources/Account/Views/AccountNavigationBarMenuView.swift
+++ b/Sources/Account/Views/AccountNavigationBarMenuView.swift
@@ -11,7 +11,7 @@ import Common
 import PushNotifications
 
 struct AccountNavigationBarMenuView: View {
-    @StateObject private var viewModel = AccountNavigationBarMenuViewModel()
+    @State private var viewModel = AccountNavigationBarMenuViewModel()
 
     @Binding var error: UserFacingError?
 

--- a/Sources/Account/Views/AccountNavigationBarMenuView.swift
+++ b/Sources/Account/Views/AccountNavigationBarMenuView.swift
@@ -71,7 +71,9 @@ struct AccountNavigationBarMenuView: View {
             }
         }
         .sheet(isPresented: $showPasskeySettings) {
-            PasskeySettingsView()
+            NavigationStack {
+                PasskeySettingsView()
+            }
         }
         .sheet(isPresented: $viewModel.recommendPasskey) {
             NavigationStack {

--- a/Sources/Account/Views/AccountNavigationBarMenuView.swift
+++ b/Sources/Account/Views/AccountNavigationBarMenuView.swift
@@ -57,6 +57,9 @@ struct AccountNavigationBarMenuView: View {
                     .frame(width: 16, height: 10)
             }
         })
+        .task {
+            await viewModel.checkPasskeyRecommendation()
+        }
         .onChange(of: viewModel.error) { _, error in
             self.error = error
         }
@@ -69,6 +72,11 @@ struct AccountNavigationBarMenuView: View {
         }
         .sheet(isPresented: $showPasskeySettings) {
             PasskeySettingsView()
+        }
+        .sheet(isPresented: $viewModel.recommendPasskey) {
+            NavigationStack {
+                PasskeyRecommendationView()
+            }
         }
     }
 }

--- a/Sources/Account/Views/PasskeyRecommendationView.swift
+++ b/Sources/Account/Views/PasskeyRecommendationView.swift
@@ -1,0 +1,52 @@
+//
+//  PasskeyRecommendationView.swift
+//  ArtemisCore
+//
+//  Created by Anian Schleyer on 27.08.25.
+//
+
+import SwiftUI
+
+struct PasskeyRecommendationView: View {
+    @Environment(\.dismiss) var dismiss
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: .xl) {
+                Image(systemName: "key.viewfinder")
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 100, height: 100)
+                    .foregroundStyle(.blue)
+                    .padding(.top)
+
+                Text(R.string.localizable.passkeyRecommendationTitle())
+                    .font(.title.bold())
+
+                Text(R.string.localizable.passkeyRecommendationBody())
+                    .multilineTextAlignment(.center)
+            }
+        }
+        .contentMargins(.xl, for: .scrollContent)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .safeAreaInset(edge: .bottom) {
+            VStack(spacing: 20) {
+                NavigationLink {
+                    PasskeySettingsView()
+                } label: {
+                    Text(R.string.localizable.setUpPasskeys())
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, .m)
+                }
+                .buttonStyle(.borderedProminent)
+
+                Button(R.string.localizable.notNow()) {
+                    dismiss()
+                }
+            }
+            .padding(20)
+            .frame(maxWidth: .infinity)
+            .background(.bar)
+        }
+    }
+}

--- a/Sources/Account/Views/PasskeyRecommendationView.swift
+++ b/Sources/Account/Views/PasskeyRecommendationView.swift
@@ -24,15 +24,16 @@ struct PasskeyRecommendationView: View {
                     .font(.title.bold())
 
                 Text(R.string.localizable.passkeyRecommendationBody())
-                    .multilineTextAlignment(.center)
             }
+            .multilineTextAlignment(.center)
         }
         .contentMargins(.xl, for: .scrollContent)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .safeAreaInset(edge: .bottom) {
             VStack(spacing: 20) {
                 NavigationLink {
-                    PasskeySettingsView()
+                    PasskeySettingsView(parentDismiss: dismiss.callAsFunction)
+                        .navigationBarBackButtonHidden()
                 } label: {
                     Text(R.string.localizable.setUpPasskeys())
                         .frame(maxWidth: .infinity)

--- a/Sources/Account/Views/PasskeySettingsView.swift
+++ b/Sources/Account/Views/PasskeySettingsView.swift
@@ -13,50 +13,53 @@ struct PasskeySettingsView: View {
     @State private var viewModel = PasskeySettingsViewModel()
     @Environment(\.authorizationController) var authorizationController
     @Environment(\.dismiss) var dismiss
+    var parentDismiss: (() -> Void)?
 
     var body: some View {
-        NavigationStack {
-            Form {
-                DataStateView(data: $viewModel.passkeys) {
-                    await viewModel.loadPasskeys()
-                } content: { passkeys in
-                    ForEach(passkeys, id: \Passkey.credentialId) { passkey in
-                        VStack(alignment: .leading) {
-                            Text(passkey.label)
-                                .font(.headline)
+        Form {
+            DataStateView(data: $viewModel.passkeys) {
+                await viewModel.loadPasskeys()
+            } content: { passkeys in
+                ForEach(passkeys, id: \Passkey.credentialId) { passkey in
+                    VStack(alignment: .leading) {
+                        Text(passkey.label)
+                            .font(.headline)
 
-                            Group {
-                                Text("Created at ") + Text(passkey.created, style: .date)
-                            }
-                            .font(.footnote)
+                        Group {
+                            Text("Created at ") + Text(passkey.created, style: .date)
                         }
+                        .font(.footnote)
                     }
+                }
 
-                    if passkeys.isEmpty {
-                        ContentUnavailableView(R.string.localizable.noPasskeys(),
-                                               systemImage: "key.fill",
-                                               description: Text(R.string.localizable.noPasskeysDescription))
-                    }
+                if passkeys.isEmpty {
+                    ContentUnavailableView(R.string.localizable.noPasskeys(),
+                                           systemImage: "key.fill",
+                                           description: Text(R.string.localizable.noPasskeysDescription))
+                }
 
-                    Section {
-                        Button("Add new key", systemImage: "key.fill") {
-                            Task {
-                                await viewModel.registerPasskey(controller: authorizationController)
-                            }
+                Section {
+                    Button("Add new key", systemImage: "key.fill") {
+                        Task {
+                            await viewModel.registerPasskey(controller: authorizationController)
                         }
                     }
                 }
             }
-            .onAppear {
-                Task {
-                    await viewModel.loadPasskeys()
-                }
+        }
+        .onAppear {
+            Task {
+                await viewModel.loadPasskeys()
             }
-            .navigationTitle(R.string.localizable.passkeys())
-            .loadingIndicator(isLoading: $viewModel.isLoading)
-            .toolbar {
-                ToolbarItem(placement: .primaryAction) {
-                    Button(R.string.localizable.close()) {
+        }
+        .navigationTitle(R.string.localizable.passkeys())
+        .loadingIndicator(isLoading: $viewModel.isLoading)
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button(R.string.localizable.close()) {
+                    if let parentDismiss {
+                        parentDismiss()
+                    } else {
                         dismiss()
                     }
                 }

--- a/Sources/Login/ViewModels/LoginViewModel.swift
+++ b/Sources/Login/ViewModels/LoginViewModel.swift
@@ -78,6 +78,9 @@ open class LoginViewModel: NSObject, ObservableObject {
             }
         default:
             isLoading = false
+            if UserSessionFactory.shared.isLoggedIn {
+                UserSessionFactory.shared.didLogInWithPassword = true
+            }
             return
         }
     }

--- a/Sources/Login/ViewModels/LoginViewModel.swift
+++ b/Sources/Login/ViewModels/LoginViewModel.swift
@@ -78,7 +78,8 @@ open class LoginViewModel: NSObject, ObservableObject {
             }
         default:
             isLoading = false
-            if UserSessionFactory.shared.isLoggedIn {
+            let isTumUrl = UserSessionFactory.shared.institution?.baseURL?.absoluteString.contains(".tum.") ?? false
+            if UserSessionFactory.shared.isLoggedIn && isTumUrl {
                 UserSessionFactory.shared.didLogInWithPassword = true
             }
             return

--- a/Sources/UserStore/UserSession.swift
+++ b/Sources/UserStore/UserSession.swift
@@ -16,6 +16,8 @@ public class UserSession: ObservableObject {
     @Published public internal(set) var username: String?
     @Published public internal(set) var password: String?
     @Published public internal(set) var tokenExpired = false
+    /// Temporarily save login method to recommend passkeys
+    @Published public var didLogInWithPassword = false
 
     // Push Notifications
     @Published internal var notificationDeviceConfigurations: [NotificationDeviceConfiguration] = []


### PR DESCRIPTION
When a user
- logs in using username + password, and
- did not set up passkeys already, and
- is using a TUM instance of Artemis (we don't support passkeys for others yet)

then we want to display a recommendation to add a passkey to their account.

<img width="300" alt="Passkey recommendation screen" src="https://github.com/user-attachments/assets/d1f91987-25a5-48de-8146-79fafc467218" />
