### PR TITLE
`Course`: Replace faqEnabled with numberOfAcceptedFaqs

### DIFF
--- a/Sources/SharedModels/Course/Course.swift
+++ b/Sources/SharedModels/Course/Course.swift
@@ -25,7 +25,7 @@ public struct Course: Codable, Identifiable {
     public var instructorGroupName: String?
     public var editorGroupName: String?
     public var teachingAssistantGroupName: String?
-    public var faqEnabled: Bool?
+    public var numberOfAcceptedFaqs: Int?
 
     // helper attributes, if DTO does not contain complete data
     public var numberOfLectures: Int?


### PR DESCRIPTION
To align with changes in https://github.com/ls1intum/Artemis/pull/12285, we need to replace the `faqEnabled` property with `numberOfAcceptedFaqs`. This number is then used to decide whether to show or not show the FAQ tab.