### PR TITLE
`Development`: Adjust openapi sync action

### DIFF
--- a/.github/workflows/sync-openapi-spec.yml
+++ b/.github/workflows/sync-openapi-spec.yml
@@ -1,6 +1,7 @@
 name: Sync OpenAPI spec from Artemis
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 * * * *"
   
@@ -11,6 +12,8 @@ jobs:
     steps:
       - name: Checkout target repo
         uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download OpenAPI file
         run: |
@@ -29,3 +32,4 @@ jobs:
           branch: sync-openapi
           title: "`Development`: Sync OpenAPI spec"
           base: main
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-openapi-spec.yml
+++ b/.github/workflows/sync-openapi-spec.yml
@@ -1,7 +1,6 @@
 name: Sync OpenAPI spec from Artemis
 
 on:
-  workflow_dispatch:
   push:
   schedule:
     - cron: "0 * * * *"
@@ -14,7 +13,7 @@ jobs:
       - name: Checkout target repo
         uses: actions/checkout@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
 
       - name: Download OpenAPI file
         run: |

--- a/.github/workflows/sync-openapi-spec.yml
+++ b/.github/workflows/sync-openapi-spec.yml
@@ -1,9 +1,8 @@
 name: Sync OpenAPI spec from Artemis
 
 on:
-  push:
   schedule:
-    - cron: "0 * * * *"
+    - cron: "0 0 * * *"
   
 jobs:
   sync:

--- a/.github/workflows/sync-openapi-spec.yml
+++ b/.github/workflows/sync-openapi-spec.yml
@@ -2,6 +2,7 @@ name: Sync OpenAPI spec from Artemis
 
 on:
   workflow_dispatch:
+  push:
   schedule:
     - cron: "0 * * * *"
   


### PR DESCRIPTION
Adjust the GitHub action to run daily and correctly create a PR