### PR TITLE
`APIClient`: Improve cookie handling between app extensions

### DIFF
--- a/Sources/APIClient/APIClient.swift
+++ b/Sources/APIClient/APIClient.swift
@@ -244,6 +244,24 @@ extension APIClient {
     }
 }
 
+public extension APIClient {
+    static func setupCurrentJWT() {
+        if let token = UserSessionFactory.shared.getToken() {
+            let properties: [HTTPCookiePropertyKey: Any] = [
+                .name: "jwt",
+                .value: token,
+                .secure: true,
+                .domain: UserSessionFactory.shared.institution?.baseURL?.host() ?? "",
+                .path: "/",
+                .version: 0
+            ]
+            if let cookie = HTTPCookie(properties: properties) {
+                URLSession.shared.configuration.httpCookieStorage?.setCookie(cookie)
+            }
+        }
+    }
+}
+
 private extension Formatter {
     static let iso8601withFractionalSeconds: DateFormatter = {
         let formatter = DateFormatter()

--- a/Sources/PushNotifications/PushNotificationHandler+Communication.swift
+++ b/Sources/PushNotifications/PushNotificationHandler+Communication.swift
@@ -89,7 +89,7 @@ public extension PushNotificationHandler {
                 .name: "jwt",
                 .value: token,
                 .secure: true,
-                .domain: UserSessionFactory.shared.institution?.baseURL?.absoluteString ?? "",
+                .domain: UserSessionFactory.shared.institution?.baseURL?.host() ?? "",
                 .path: "/",
                 .version: 0
             ]


### PR DESCRIPTION
Adds a convenience function to APIClient that allows using the app's JWT cookie in an extension by calling one line of code.