### PR TITLE
`Iris`: Add irisEnabledInCourse flag to Course and CourseForDashboardDTO

### DIFF
--- a/Sources/SharedModels/Course/Course.swift
+++ b/Sources/SharedModels/Course/Course.swift
@@ -30,6 +30,9 @@ public struct Course: Codable, Identifiable {
     // helper attributes, if DTO does not contain complete data
     public var numberOfLectures: Int?
 
+    /// Enabled state of the Iris course chat, copied over from `CourseForDashboardDTO`.
+    public var irisEnabledInCourse: Bool?
+
     public var courseIconURL: URL? {
         guard let courseIcon else { return nil }
         let baseUrl = UserSessionFactory.shared.institution?.baseURL?.appending(path: "api/core/files")

--- a/Sources/SharedModels/Course/CourseForDashboardDTO.swift
+++ b/Sources/SharedModels/Course/CourseForDashboardDTO.swift
@@ -17,6 +17,7 @@ public struct CourseForDashboardDTO: Codable {
     public var quizScores: CourseScore?
     public var participationResults: [ParticipationResultDTO]?
     public var courseNotificationCount: Int?
+    public var irisEnabledInCourse: Bool?
 }
 
 public extension CourseForDashboardDTO {

--- a/Sources/SharedServices/CourseService/CourseServiceImpl.swift
+++ b/Sources/SharedServices/CourseService/CourseServiceImpl.swift
@@ -51,6 +51,9 @@ struct CourseServiceImpl: CourseService {
 
         switch result {
         case let .success((response, _)):
+            // Mirror the web client and copy it onto the course so views can read it directly.
+            var response = response
+            response.course.irisEnabledInCourse = response.irisEnabledInCourse
             return .done(response: response)
         case let .failure(error):
             return .failure(error: UserFacingError(error: error))


### PR DESCRIPTION
> [!NOTE]
>This PR is a prerequisite for [PR #492](https://github.com/ls1intum/artemis-ios/pull/492)

Exposes whether Iris is enabled for a course, so client apps can show/hide the Iris tab accordingly. 
  
### Changes
- **`CourseForDashboardDTO`**: decode the new `irisEnabledInCourse` flag — the server sends it as a sibling of `course` on the `…/for-dashboard` endpoint.
- **`Course`**: add `irisEnabledInCourse` so the flag survives after the DTO wrapper is dropped (e.g. `map(\.course)`) and is readable in the UI layer.
- **`CourseServiceImpl.getCourse`**: copy the flag from the DTO onto `course`, matching the web client's `course-management.service.ts`. 
    
Optional field, defaults to `nil` → backward-compatible.