### PR TITLE
`Iris`: Add push notifications

### DIFF
--- a/Sources/APIClient/APIClient.swift
+++ b/Sources/APIClient/APIClient.swift
@@ -6,6 +6,12 @@ import UserStore
 // swiftlint:disable force_cast
 public final class APIClient {
 
+    /// HTTP header name through which the app identifies its client type to the server.
+    private static let clientHeaderField = "X-Artemis-Client"
+
+    /// Value sent in ``clientHeaderField`` to identify requests as originating from the iOS app.
+    private static let clientHeaderValue = "ios"
+
     internal let session = URLSession.shared
 
     internal var baseUrl: URL? {
@@ -21,7 +27,8 @@ public final class APIClient {
     ///   - request: A MultipartFormDataRequest object that provides HTTPmethod, path, data to send and type of response.
     ///   - currentTry: A counter which try the current is, used for retry mechanism
     public func sendRequest<T: Decodable>(_ request: MultipartFormDataRequest, currentTry: Int = 1) async -> Result<(T, Int), APIClientError> {
-        let urlRequest = request.asURLRequest()
+        var urlRequest = request.asURLRequest()
+        urlRequest.setValue(Self.clientHeaderValue, forHTTPHeaderField: Self.clientHeaderField)
         printRequest(urlRequest: urlRequest)
 
         do {
@@ -90,6 +97,7 @@ public final class APIClient {
 
         urlRequest.httpMethod = request.method.description
         urlRequest.url?.append(queryItems: request.params)
+        urlRequest.setValue(Self.clientHeaderValue, forHTTPHeaderField: Self.clientHeaderField)
         // urlRequests are not forcing to ignore cached data. That's why it might be possible to see older data. Also the statusCode 304 (send on server-side) will be changed to a 200. For more information see (https://stackoverflow.com/q/46696624)
 
         // NOTE: GET requests with body are never sent

--- a/Sources/APIClient/APIClient.swift
+++ b/Sources/APIClient/APIClient.swift
@@ -6,12 +6,6 @@ import UserStore
 // swiftlint:disable force_cast
 public final class APIClient {
 
-    /// HTTP header name through which the app identifies its client type to the server.
-    private static let clientHeaderField = "X-Artemis-Client"
-
-    /// Value sent in ``clientHeaderField`` to identify requests as originating from the iOS app.
-    private static let clientHeaderValue = "ios"
-
     internal let session = URLSession.shared
 
     internal var baseUrl: URL? {
@@ -27,8 +21,7 @@ public final class APIClient {
     ///   - request: A MultipartFormDataRequest object that provides HTTPmethod, path, data to send and type of response.
     ///   - currentTry: A counter which try the current is, used for retry mechanism
     public func sendRequest<T: Decodable>(_ request: MultipartFormDataRequest, currentTry: Int = 1) async -> Result<(T, Int), APIClientError> {
-        var urlRequest = request.asURLRequest()
-        urlRequest.setValue(Self.clientHeaderValue, forHTTPHeaderField: Self.clientHeaderField)
+        let urlRequest = request.asURLRequest()
         printRequest(urlRequest: urlRequest)
 
         do {
@@ -97,7 +90,6 @@ public final class APIClient {
 
         urlRequest.httpMethod = request.method.description
         urlRequest.url?.append(queryItems: request.params)
-        urlRequest.setValue(Self.clientHeaderValue, forHTTPHeaderField: Self.clientHeaderField)
         // urlRequests are not forcing to ignore cached data. That's why it might be possible to see older data. Also the statusCode 304 (send on server-side) will be changed to a 200. For more information see (https://stackoverflow.com/q/46696624)
 
         // NOTE: GET requests with body are never sent

--- a/Sources/PushNotifications/Models/CoursePushNotification.swift
+++ b/Sources/PushNotifications/Models/CoursePushNotification.swift
@@ -41,6 +41,7 @@ public enum CoursePushNotification: Codable {
     case tutorialAssigned(TutorialGroupAssignedNotification)
     case tutorialDeleted(TutorialGroupDeletedNotification)
     case tutorialUnassigned(TutorialGroupUnassignedNotification)
+    case irisResponse(IrisResponseNotification)
     case unknown
 
     /// Initializer for using different CodingKeys.
@@ -77,6 +78,7 @@ public enum CoursePushNotification: Codable {
         case .tutorialGroupAssignedNotification: .tutorialAssigned(try decodeNotification())
         case .tutorialGroupDeletedNotification: .tutorialDeleted(try decodeNotification())
         case .tutorialGroupUnassignedNotification: .tutorialUnassigned(try decodeNotification())
+        case .irisResponseNotification: .irisResponse(try decodeNotification())
         case .unknown: .unknown
         }
     }
@@ -110,6 +112,7 @@ public enum CoursePushNotification: Codable {
         case .tutorialAssigned(let notification): notification
         case .tutorialDeleted(let notification): notification
         case .tutorialUnassigned(let notification): notification
+        case .irisResponse(let notification): notification
         default:
             nil
         }
@@ -161,6 +164,7 @@ public enum CourseNotificationType: String, Codable, CodingKeyRepresentable, Con
     case tutorialGroupAssignedNotification
     case tutorialGroupDeletedNotification
     case tutorialGroupUnassignedNotification
+    case irisResponseNotification
     case unknown
 }
 

--- a/Sources/PushNotifications/Models/General/IrisResponseNotification.swift
+++ b/Sources/PushNotifications/Models/General/IrisResponseNotification.swift
@@ -1,0 +1,33 @@
+//
+//  IrisResponseNotification.swift
+//  ArtemisCore
+//
+//  Created by Senan Aslan on 11.06.26.
+//
+
+public struct IrisResponseNotification: CourseBaseNotification {
+    public var courseId: Int?
+    public var courseTitle: String?
+    public var courseIconUrl: String?
+
+    public var sessionId: Int?
+    public var messagePreview: String?
+    public var chatTitle: String?
+}
+
+extension IrisResponseNotification: DisplayableNotification {
+    public var title: String {
+        "Iris\n\(chatTitle ?? "")"
+    }
+
+    public var body: String? {
+        messagePreview
+    }
+}
+
+extension IrisResponseNotification: NavigatableNotification {
+    public var relativePath: String? {
+        guard let courseId, let sessionId else { return nil }
+        return "courses/\(courseId)/iris?sessionId=\(sessionId)"
+    }
+}

--- a/Sources/PushNotifications/Models/General/IrisResponseNotification.swift
+++ b/Sources/PushNotifications/Models/General/IrisResponseNotification.swift
@@ -17,7 +17,11 @@ public struct IrisResponseNotification: CourseBaseNotification {
 
 extension IrisResponseNotification: DisplayableNotification {
     public var title: String {
-        "Iris\n\(chatTitle ?? "")"
+        if chatTitle != nil {
+            "Iris - \(chatTitle!)"
+        } else {
+            "Iris"
+        }
     }
 
     public var body: String? {

--- a/Sources/PushNotifications/Models/General/IrisResponseNotification.swift
+++ b/Sources/PushNotifications/Models/General/IrisResponseNotification.swift
@@ -17,8 +17,8 @@ public struct IrisResponseNotification: CourseBaseNotification {
 
 extension IrisResponseNotification: DisplayableNotification {
     public var title: String {
-        if chatTitle != nil {
-            "Iris - \(chatTitle!)"
+        if let chatTitle {
+            "Iris - \(chatTitle)"
         } else {
             "Iris"
         }

--- a/Sources/PushNotifications/Models/NotificationSettings.swift
+++ b/Sources/PushNotifications/Models/NotificationSettings.swift
@@ -79,6 +79,8 @@ extension CourseNotificationType {
             R.string.localizable.tutorialDeletedSettingsName()
         case .tutorialGroupUnassignedNotification:
             R.string.localizable.tutorialUnassignedSettingsName()
+        case .irisResponseNotification:
+            "Iris"
         case .unknown:
             ""
         }


### PR DESCRIPTION
> [!NOTE]
> This PR is linked to [PR #496](https://github.com/ls1intum/artemis-ios/pull/496) on artemis-ios & [PR #12902](https://github.com/ls1intum/Artemis/pull/12902) on Artemis

## Summary
Adds support for **Iris** push notifications. When Iris responds in a chat session, the user now receives a push notification that opens the corresponding Iris chat.

## Changes
- **New notification type `IrisResponseNotification`**: carries `courseId`, `sessionId`, `messagePreview` and `chatTitle`.
  - Displays as `Iris - <chatTitle>` (or just `Iris` when no chat title is present), with the message preview as the body.
  - Deep links into the Iris chat via `courses/{courseId}/iris?sessionId={sessionId}`.
- **Wired `irisResponseNotification` into `CoursePushNotification`** decoding, payload extraction and the `CourseNotificationType` enum, plus a notification settings entry labelled "Iris".

## Review Note
The header value `clientHeaderValue = "ios"` was added on both request paths (`sendRequest(_:MultipartFormDataRequest:)` and the standard request builder).
