### PR TITLE
`Iris`: Add AI Experience settings to opt in or out of AI features

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -65,6 +65,7 @@ let package = Package(
             dependencies: [
                 "APIClient",
                 "DesignLibrary",
+                "ProfileInfo",
                 "PushNotifications",
                 "SharedModels",
                 "SharedServices",

--- a/Sources/Account/Resources/en.lproj/Localizable.strings
+++ b/Sources/Account/Resources/en.lproj/Localizable.strings
@@ -16,6 +16,32 @@
 "loading" = "Loading...";
 "notNow" = "Not now";
 
+// MARK: AI Experience Settings
+"aiExperienceNavigationTitle" = "AI Experience";
+"aiExperienceHeader" = "Choose Your AI Experience";
+"aiExperienceSubtitle" = "Your data, your choice. You can change this at any time.";
+"aiCloudTitle" = "Cloud AI";
+"aiCloudDescription" = "Fast, high-quality AI powered by cutting-edge cloud models";
+"aiCloudFeatureLLM" = "State-of-the-art LLMs like GPT-5";
+"aiCloudFeatureQuality" = "High response quality";
+"aiCloudFeatureSpeed" = "Fast response times";
+"aiCloudFeatureGdpr" = "GDPR-compliant processing on Azure";
+"aiCloudFeatureData" = "All data stored on university datacenters";
+"aiLocalTitle" = "On-premise";
+"aiLocalDescription" = "Ideal for highest privacy, but with some limitations";
+"aiLocalFeatureLLM" = "Latest open-source LLMs like GPT-OSS";
+"aiLocalFeatureQuality" = "Lower response quality";
+"aiLocalFeatureSpeed" = "Slower response times";
+"aiLocalFeatureProcessing" = "Processing only in university datacenters";
+"aiLocalFeatureData" = "All data stored on university datacenters";
+"aiNoneTitle" = "No AI";
+"aiNoneDescription" = "Use Artemis without AI assistance. Iris and AI-powered feedback will be unavailable.";
+"aiRecommendedBadge" = "Recommended";
+"aiExperimentalBadge" = "Experimental";
+"aiExperienceFooter" = "Artemis will never send your personal data such as your registration number or your email address to a large language model.";
+"aiLearnMoreLink" = "Learn more about your options";
+"aiLastChangedLabel" = "Last changed";
+
 // MARK: Passkeys
 "passkeyRecommendationTitle" = "Stay secure with Passkeys";
 "passkeyRecommendationBody" = "Passkeys are a good way to improve your account's security. Your device securely creates and stores a key to log in to your Artemis account.\n\nUnlike a password, passkeys can not be easily guessed or stolen using social engineering attacks.";

--- a/Sources/Account/ViewModels/AiExperienceSettingsViewModel.swift
+++ b/Sources/Account/ViewModels/AiExperienceSettingsViewModel.swift
@@ -1,0 +1,59 @@
+//
+//  AiExperienceSettingsViewModel.swift
+//  ArtemisCore
+//
+//  Created by Senan Aslan on 13.06.26.
+//
+
+import Common
+import Foundation
+import SharedModels
+import SharedServices
+import UserStore
+
+@MainActor
+@Observable
+class AiExperienceSettingsViewModel {
+    private let accountService: AccountService = AccountServiceFactory.shared
+
+    /// The user's current AI choice, or `nil` if they have not chosen yet.
+    var selection: AiSelectionDecision?
+    var selectionTimestamp: Date?
+    var error: UserFacingError?
+    var isLoading = false
+
+    init() {
+        let user = UserSessionFactory.shared.user
+        selection = user?.selectedLLMUsage
+        selectionTimestamp = user?.selectedLLMUsageTimestamp
+    }
+
+    /// Refreshes the account from the server so a change made elsewhere (e.g. the web client)
+    /// is reflected instead of the possibly stale cached value.
+    func load() async {
+        let response = await accountService.getAccount()
+        if case .done(let account) = response {
+            selection = account.selectedLLMUsage
+            selectionTimestamp = account.selectedLLMUsageTimestamp
+        }
+    }
+
+    func select(_ newSelection: AiSelectionDecision) async {
+        guard newSelection != selection, !isLoading else { return }
+        isLoading = true
+        defer { isLoading = false }
+
+        let response = await accountService.updateLLMSelection(newSelection)
+        switch response {
+        case .success:
+            // updateLLMSelection refreshes the cached account; read the authoritative values back.
+            let user = UserSessionFactory.shared.user
+            selection = user?.selectedLLMUsage ?? newSelection
+            selectionTimestamp = user?.selectedLLMUsageTimestamp
+        case .failure(let error):
+            self.error = .init(title: error.localizedDescription)
+        default:
+            break
+        }
+    }
+}

--- a/Sources/Account/ViewModels/AiExperienceSettingsViewModel.swift
+++ b/Sources/Account/ViewModels/AiExperienceSettingsViewModel.swift
@@ -22,6 +22,11 @@ class AiExperienceSettingsViewModel {
     var error: UserFacingError?
     var isLoading = false
 
+    /// Link to the AI experience info page on the user's currently selected Artemis instance.
+    var infoURL: URL? {
+        UserSessionFactory.shared.institution?.baseURL?.appendingPathComponent("ai-experience-info")
+    }
+
     init() {
         let user = UserSessionFactory.shared.user
         selection = user?.selectedLLMUsage

--- a/Sources/Account/Views/AccountNavigationBarMenuView.swift
+++ b/Sources/Account/Views/AccountNavigationBarMenuView.swift
@@ -72,7 +72,6 @@ struct AccountNavigationBarMenuView: View {
         })
         .task {
             await viewModel.checkPasskeyRecommendation()
-            await FeatureList.shared.checkAvailability()
         }
         .onChange(of: viewModel.error) { _, error in
             self.error = error

--- a/Sources/Account/Views/AccountNavigationBarMenuView.swift
+++ b/Sources/Account/Views/AccountNavigationBarMenuView.swift
@@ -8,10 +8,15 @@
 import SwiftUI
 import DesignLibrary
 import Common
+import ProfileInfo
 import PushNotifications
 
 struct AccountNavigationBarMenuView: View {
     @State private var viewModel = AccountNavigationBarMenuViewModel()
+
+    /// Whether the connected instance has the Iris/AI module enabled. The AI experience settings are only
+    /// relevant in that case (e.g. instances set up without any AI experience should not show this).
+    @ModuleFeatureAvailability(.iris) private var isIrisAvailable
 
     @Binding var error: UserFacingError?
 
@@ -37,8 +42,10 @@ struct AccountNavigationBarMenuView: View {
                     showPasskeySettings = true
                 }
             }
-            Button(R.string.localizable.aiExperienceNavigationTitle(), systemImage: "sparkles") {
-                showAiSettings = true
+            if isIrisAvailable {
+                Button(R.string.localizable.aiExperienceNavigationTitle(), systemImage: "sparkles") {
+                    showAiSettings = true
+                }
             }
             Button(R.string.localizable.logoutLabel()) {
                 viewModel.logout()
@@ -65,6 +72,7 @@ struct AccountNavigationBarMenuView: View {
         })
         .task {
             await viewModel.checkPasskeyRecommendation()
+            await FeatureList.shared.checkAvailability()
         }
         .onChange(of: viewModel.error) { _, error in
             self.error = error

--- a/Sources/Account/Views/AccountNavigationBarMenuView.swift
+++ b/Sources/Account/Views/AccountNavigationBarMenuView.swift
@@ -17,6 +17,7 @@ struct AccountNavigationBarMenuView: View {
 
     @State private var showProfile = false
     @State private var showPasskeySettings = false
+    @State private var showAiSettings = false
 
     var body: some View {
         Menu(content: {
@@ -35,6 +36,9 @@ struct AccountNavigationBarMenuView: View {
                 Button("Manage Passkeys", systemImage: "key.fill") {
                     showPasskeySettings = true
                 }
+            }
+            Button(R.string.localizable.aiExperienceNavigationTitle(), systemImage: "sparkles") {
+                showAiSettings = true
             }
             Button(R.string.localizable.logoutLabel()) {
                 viewModel.logout()
@@ -75,6 +79,11 @@ struct AccountNavigationBarMenuView: View {
         .sheet(isPresented: $showPasskeySettings) {
             NavigationStack {
                 PasskeySettingsView()
+            }
+        }
+        .sheet(isPresented: $showAiSettings) {
+            NavigationStack {
+                AiExperienceSettingsView()
             }
         }
         .sheet(isPresented: $viewModel.recommendPasskey) {

--- a/Sources/Account/Views/AiExperienceSettingsView.swift
+++ b/Sources/Account/Views/AiExperienceSettingsView.swift
@@ -1,0 +1,188 @@
+//
+//  AiExperienceSettingsView.swift
+//  ArtemisCore
+//
+//  Created by Senan Aslan on 13.06.26.
+//
+
+import DesignLibrary
+import SharedModels
+import SwiftUI
+
+struct AiExperienceSettingsView: View {
+    @State private var viewModel = AiExperienceSettingsViewModel()
+    @Environment(\.dismiss) var dismiss
+
+    private var errorBinding: Binding<Bool> {
+        Binding(get: { viewModel.error != nil }, set: { if !$0 { viewModel.error = nil } })
+    }
+
+    private let options: [AiSelectionDecision] = [.cloudAI, .localAI, .noAI]
+
+    var body: some View {
+        Form {
+            Section {
+                ForEach(options, id: \.self) { option in
+                    Button {
+                        Task { await viewModel.select(option) }
+                    } label: {
+                        row(for: option)
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(viewModel.isLoading)
+                }
+            } header: {
+                VStack(alignment: .leading, spacing: .s) {
+                    Text(R.string.localizable.aiExperienceHeader())
+                        .font(.headline)
+                    Text(R.string.localizable.aiExperienceSubtitle())
+                        .font(.subheadline)
+                }
+            } footer: {
+                VStack(alignment: .leading, spacing: .s) {
+                    Text(R.string.localizable.aiExperienceFooter())
+                    if let timestamp = viewModel.selectionTimestamp {
+                        Text(R.string.localizable.aiLastChangedLabel()) + Text(" ") + Text(timestamp, style: .date)
+                    }
+                }
+            }
+        }
+        .navigationTitle(R.string.localizable.aiExperienceNavigationTitle())
+        .navigationBarTitleDisplayMode(.inline)
+        .task { await viewModel.load() }
+        .loadingIndicator(isLoading: $viewModel.isLoading)
+        .alert(viewModel.error?.title ?? "", isPresented: errorBinding) {
+            Button(R.string.localizable.close(), role: .cancel) {}
+        }
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button(R.string.localizable.close()) {
+                    dismiss()
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func row(for option: AiSelectionDecision) -> some View {
+        HStack(alignment: .top, spacing: .m) {
+            Image(systemName: icon(for: option))
+                .font(.title3)
+                .frame(width: 28)
+                .foregroundStyle(option == .noAI ? Color.secondary : Color.accentColor)
+
+            VStack(alignment: .leading, spacing: .xs) {
+                HStack(spacing: .s) {
+                    Text(title(for: option))
+                        .font(.headline)
+                    badge(for: option)
+                }
+                Text(description(for: option))
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+
+                if let features = features(for: option) {
+                    featureBox(features)
+                }
+            }
+
+            // Always reserve space for the checkmark so the text column keeps a
+            // constant width and does not reflow when the selection changes.
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(.green)
+                .opacity(viewModel.selection == option ? 1 : 0)
+        }
+        .contentShape(.rect)
+    }
+
+    private func icon(for option: AiSelectionDecision) -> String {
+        switch option {
+        case .cloudAI: "cloud.fill"
+        case .localAI: "building.columns.fill"
+        case .noAI: "nosign"
+        }
+    }
+
+    private func title(for option: AiSelectionDecision) -> String {
+        switch option {
+        case .cloudAI: R.string.localizable.aiCloudTitle()
+        case .localAI: R.string.localizable.aiLocalTitle()
+        case .noAI: R.string.localizable.aiNoneTitle()
+        }
+    }
+
+    private func description(for option: AiSelectionDecision) -> String {
+        switch option {
+        case .cloudAI: R.string.localizable.aiCloudDescription()
+        case .localAI: R.string.localizable.aiLocalDescription()
+        case .noAI: R.string.localizable.aiNoneDescription()
+        }
+    }
+
+    @ViewBuilder
+    private func badge(for option: AiSelectionDecision) -> some View {
+        switch option {
+        case .cloudAI:
+            badgeLabel(R.string.localizable.aiRecommendedBadge(), color: .accentColor)
+        case .localAI:
+            badgeLabel(R.string.localizable.aiExperimentalBadge(), color: .orange)
+        case .noAI:
+            EmptyView()
+        }
+    }
+
+    private func badgeLabel(_ text: String, color: Color) -> some View {
+        Text(text)
+            .font(.caption2.weight(.semibold))
+            .padding(.horizontal, .s)
+            .background(color.opacity(0.15), in: Capsule())
+            .foregroundStyle(color)
+    }
+
+    private struct AiFeature: Hashable {
+        let text: String
+        let systemName: String
+        let color: Color
+    }
+
+    private func features(for option: AiSelectionDecision) -> [AiFeature]? {
+        switch option {
+        case .cloudAI:
+            [
+                AiFeature(text: R.string.localizable.aiCloudFeatureLLM(), systemName: "checkmark", color: .green),
+                AiFeature(text: R.string.localizable.aiCloudFeatureQuality(), systemName: "checkmark", color: .green),
+                AiFeature(text: R.string.localizable.aiCloudFeatureSpeed(), systemName: "checkmark", color: .green),
+                AiFeature(text: R.string.localizable.aiCloudFeatureGdpr(), systemName: "checkmark", color: .green),
+                AiFeature(text: R.string.localizable.aiCloudFeatureData(), systemName: "checkmark", color: .green)
+            ]
+        case .localAI:
+            [
+                AiFeature(text: R.string.localizable.aiLocalFeatureLLM(), systemName: "checkmark", color: .green),
+                AiFeature(text: R.string.localizable.aiLocalFeatureQuality(), systemName: "info.circle", color: .secondary),
+                AiFeature(text: R.string.localizable.aiLocalFeatureSpeed(), systemName: "info.circle", color: .secondary),
+                AiFeature(text: R.string.localizable.aiLocalFeatureProcessing(), systemName: "checkmark", color: .green),
+                AiFeature(text: R.string.localizable.aiLocalFeatureData(), systemName: "checkmark", color: .green)
+            ]
+        case .noAI:
+            nil
+        }
+    }
+
+    private func featureBox(_ features: [AiFeature]) -> some View {
+        VStack(alignment: .leading, spacing: .m) {
+            ForEach(features, id: \.self) { feature in
+                HStack(alignment: .firstTextBaseline, spacing: .m) {
+                    Image(systemName: feature.systemName)
+                        .font(.caption.weight(.bold))
+                        .foregroundStyle(feature.color)
+                    Text(feature.text)
+                        .font(.subheadline.weight(.medium))
+                }
+            }
+        }
+        .padding(.m)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: .m))
+        .padding(.top, .s)
+    }
+}

--- a/Sources/Account/Views/AiExperienceSettingsView.swift
+++ b/Sources/Account/Views/AiExperienceSettingsView.swift
@@ -15,8 +15,6 @@ struct AiExperienceSettingsView: View {
     @State private var isLearnMorePresented = false
     @Environment(\.dismiss) var dismiss
 
-    private let infoURL = URL(string: "https://artemis.tum.de/ai-experience-info")
-
     private var errorBinding: Binding<Bool> {
         Binding(get: { viewModel.error != nil }, set: { if !$0 { viewModel.error = nil } })
     }
@@ -45,7 +43,7 @@ struct AiExperienceSettingsView: View {
             } footer: {
                 VStack(alignment: .leading, spacing: .s) {
                     Text(R.string.localizable.aiExperienceFooter())
-                    if infoURL != nil {
+                    if viewModel.infoURL != nil {
                         Button(R.string.localizable.aiLearnMoreLink()) {
                             isLearnMorePresented = true
                         }
@@ -60,7 +58,7 @@ struct AiExperienceSettingsView: View {
         .navigationTitle(R.string.localizable.aiExperienceNavigationTitle())
         .navigationBarTitleDisplayMode(.inline)
         .sheet(isPresented: $isLearnMorePresented) {
-            if let infoURL {
+            if let infoURL = viewModel.infoURL {
                 SafariView(url: infoURL)
                     .ignoresSafeArea()
             }

--- a/Sources/Account/Views/AiExperienceSettingsView.swift
+++ b/Sources/Account/Views/AiExperienceSettingsView.swift
@@ -10,10 +10,18 @@ import SafariServices
 import SharedModels
 import SwiftUI
 
-struct AiExperienceSettingsView: View {
+public struct AiExperienceSettingsView: View {
     @State private var viewModel = AiExperienceSettingsViewModel()
     @State private var isLearnMorePresented = false
     @Environment(\.dismiss) var dismiss
+
+    /// Called after the user changes their AI selection, with the new value.
+    /// Lets a presenting screen (e.g. the Iris consent gate) react without observing the cached account.
+    private let onSelectionChange: ((AiSelectionDecision?) -> Void)?
+
+    public init(onSelectionChange: ((AiSelectionDecision?) -> Void)? = nil) {
+        self.onSelectionChange = onSelectionChange
+    }
 
     private var errorBinding: Binding<Bool> {
         Binding(get: { viewModel.error != nil }, set: { if !$0 { viewModel.error = nil } })
@@ -21,12 +29,15 @@ struct AiExperienceSettingsView: View {
 
     private let options: [AiSelectionDecision] = [.cloudAI, .localAI, .noAI]
 
-    var body: some View {
+    public var body: some View {
         Form {
             Section {
                 ForEach(options, id: \.self) { option in
                     Button {
-                        Task { await viewModel.select(option) }
+                        Task {
+                            await viewModel.select(option)
+                            onSelectionChange?(viewModel.selection)
+                        }
                     } label: {
                         row(for: option)
                     }
@@ -201,9 +212,6 @@ struct AiExperienceSettingsView: View {
     }
 }
 
-/// Presents a URL in an in-app `SFSafariViewController`. Using an embedded web view
-/// avoids the host app's universal-link interception, which would otherwise show a
-/// "Link not supported by App" alert for `artemis.tum.de` URLs on a real device.
 private struct SafariView: UIViewControllerRepresentable {
     let url: URL
 

--- a/Sources/Account/Views/AiExperienceSettingsView.swift
+++ b/Sources/Account/Views/AiExperienceSettingsView.swift
@@ -6,12 +6,16 @@
 //
 
 import DesignLibrary
+import SafariServices
 import SharedModels
 import SwiftUI
 
 struct AiExperienceSettingsView: View {
     @State private var viewModel = AiExperienceSettingsViewModel()
+    @State private var isLearnMorePresented = false
     @Environment(\.dismiss) var dismiss
+
+    private let infoURL = URL(string: "https://artemis.tum.de/ai-experience-info")
 
     private var errorBinding: Binding<Bool> {
         Binding(get: { viewModel.error != nil }, set: { if !$0 { viewModel.error = nil } })
@@ -41,6 +45,12 @@ struct AiExperienceSettingsView: View {
             } footer: {
                 VStack(alignment: .leading, spacing: .s) {
                     Text(R.string.localizable.aiExperienceFooter())
+                    if infoURL != nil {
+                        Button(R.string.localizable.aiLearnMoreLink()) {
+                            isLearnMorePresented = true
+                        }
+                        .font(.footnote)
+                    }
                     if let timestamp = viewModel.selectionTimestamp {
                         Text(R.string.localizable.aiLastChangedLabel()) + Text(" ") + Text(timestamp, style: .date)
                     }
@@ -49,6 +59,12 @@ struct AiExperienceSettingsView: View {
         }
         .navigationTitle(R.string.localizable.aiExperienceNavigationTitle())
         .navigationBarTitleDisplayMode(.inline)
+        .sheet(isPresented: $isLearnMorePresented) {
+            if let infoURL {
+                SafariView(url: infoURL)
+                    .ignoresSafeArea()
+            }
+        }
         .task { await viewModel.load() }
         .loadingIndicator(isLoading: $viewModel.isLoading)
         .alert(viewModel.error?.title ?? "", isPresented: errorBinding) {
@@ -185,4 +201,17 @@ struct AiExperienceSettingsView: View {
         .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: .m))
         .padding(.top, .s)
     }
+}
+
+/// Presents a URL in an in-app `SFSafariViewController`. Using an embedded web view
+/// avoids the host app's universal-link interception, which would otherwise show a
+/// "Link not supported by App" alert for `artemis.tum.de` URLs on a real device.
+private struct SafariView: UIViewControllerRepresentable {
+    let url: URL
+
+    func makeUIViewController(context: Context) -> SFSafariViewController {
+        SFSafariViewController(url: url)
+    }
+
+    func updateUIViewController(_ uiViewController: SFSafariViewController, context: Context) {}
 }

--- a/Sources/ProfileInfo/FeatureAvailability/FeatureAvailability.swift
+++ b/Sources/ProfileInfo/FeatureAvailability/FeatureAvailability.swift
@@ -24,3 +24,23 @@ public enum Feature: String {
     case courseNotifications = "CourseSpecificNotifications"
     case globalSearch = "GlobalSearch"
 }
+
+/// Property Wrapper for checking whether a module feature is enabled on the instance, thus conditionally hiding Views.
+///
+/// Module features are configured via Spring properties on the server (e.g. an instance set up without Iris/AI),
+/// which is complementary to ``FeatureAvailability`` that reflects feature toggles.
+@propertyWrapper
+public struct ModuleFeatureAvailability {
+    private let feature: ModuleFeature
+    public init(_ feature: ModuleFeature) {
+        self.feature = feature
+    }
+
+    public var wrappedValue: Bool {
+        FeatureList.shared.availableModuleFeatures.contains(feature.rawValue)
+    }
+}
+
+public enum ModuleFeature: String {
+    case iris
+}

--- a/Sources/ProfileInfo/FeatureAvailability/FeatureList.swift
+++ b/Sources/ProfileInfo/FeatureAvailability/FeatureList.swift
@@ -13,6 +13,7 @@ public class FeatureList {
     public static let shared = FeatureList()
 
     var availableFeatures = [String]()
+    var availableModuleFeatures = [String]()
     public var compatibleVersions: PlatformVersionCompatibility?
 
     private var lastChecked: Date = .distantPast
@@ -31,6 +32,7 @@ public class FeatureList {
                 lastChecked = .distantPast
             case .done(let response):
                 availableFeatures = response.features
+                availableModuleFeatures = response.activeModuleFeatures ?? []
                 compatibleVersions = response.compatibleVersions
                 lastChecked = .now
             default:

--- a/Sources/ProfileInfo/Model/ProfileInfo.swift
+++ b/Sources/ProfileInfo/Model/ProfileInfo.swift
@@ -24,6 +24,7 @@ public struct ProfileInfo: Codable {
     public let useExternal: Bool
     public let buildPlanURLTemplate: String?
     public let activeProfiles: [String]
+    public let activeModuleFeatures: [String]?
     public let compatibleVersions: PlatformVersionCompatibility?
     public let saml2: Saml2?
 }

--- a/Sources/SharedModels/User/Account.swift
+++ b/Sources/SharedModels/User/Account.swift
@@ -15,6 +15,8 @@ public struct Account: Codable {
     public let lastNotificationRead: Date?
     public let visibleRegistrationNumber: String?
     public let createdDate: Date?
+    public let selectedLLMUsage: AiSelectionDecision?
+    public let selectedLLMUsageTimestamp: Date?
 
     public static func hasGroup(group: String?) -> Bool {
         guard let group,
@@ -59,11 +61,25 @@ public extension Account {
         groups: ["tumuser"],
         lastNotificationRead: .yesterday,
         visibleRegistrationNumber: "04242424",
-        createdDate: .distantPast
+        createdDate: .distantPast,
+        selectedLLMUsage: .cloudAI,
+        selectedLLMUsageTimestamp: .distantPast
     )
 }
 
 public typealias User = Account
+
+/// The user's AI usage consent. Mirrors the server `AiSelectionDecision`.
+public enum AiSelectionDecision: String, Codable {
+    case noAI = "NO_AI"
+    case localAI = "LOCAL_AI"
+    case cloudAI = "CLOUD_AI"
+
+    /// `true` if Iris/AI features may run for this choice (not opted out).
+    public var isAIEnabled: Bool {
+        self == .cloudAI || self == .localAI
+    }
+}
 
 public enum Authority: String, RawRepresentable, Codable {
     case admin = "ROLE_ADMIN"

--- a/Sources/SharedServices/AccountService/AccountService.swift
+++ b/Sources/SharedServices/AccountService/AccountService.swift
@@ -14,6 +14,11 @@ public protocol AccountService {
      * Perform a login request to the server.
      */
     func getAccount() async -> DataState<Account>
+
+    /**
+     * Persist the user's AI usage choice (PUT users/select-llm-usage) and refresh the cached account.
+     */
+    func updateLLMSelection(_ selection: AiSelectionDecision) async -> NetworkResponse
 }
 
 public enum AccountServiceFactory: DependencyFactory {

--- a/Sources/SharedServices/AccountService/AccountServiceImpl.swift
+++ b/Sources/SharedServices/AccountService/AccountServiceImpl.swift
@@ -37,4 +37,31 @@ struct AccountServiceImpl: AccountService {
             return DataState(error: error)
         }
     }
+
+    struct SelectLLMUsageRequest: APIRequest {
+        typealias Response = RawResponse
+
+        let selection: AiSelectionDecision
+
+        var method: HTTPMethod {
+            return .put
+        }
+
+        var resourceName: String {
+            return "api/account/users/select-llm-usage"
+        }
+    }
+
+    func updateLLMSelection(_ selection: AiSelectionDecision) async -> NetworkResponse {
+        let result = await client.sendRequest(SelectLLMUsageRequest(selection: selection))
+
+        switch result {
+        case .success:
+            // Refresh the cached account so the new choice is reflected app-wide (e.g. the Iris gate).
+            _ = await getAccount()
+            return .success
+        case .failure(let error):
+            return .failure(error: error)
+        }
+    }
 }

--- a/Sources/SharedServices/AccountService/AccountServiceStub.swift
+++ b/Sources/SharedServices/AccountService/AccountServiceStub.swift
@@ -15,4 +15,8 @@ struct AccountServiceStub: AccountService {
         UserSessionFactory.shared.user = Account.mock
         return .done(response: Account.mock)
     }
+
+    func updateLLMSelection(_ selection: AiSelectionDecision) async -> NetworkResponse {
+        return .success
+    }
 }


### PR DESCRIPTION
> [!NOTE]
> This PR is related to [PR #500](https://github.com/ls1intum/artemis-ios/pull/500) in artemis-ios

## Summary

Adds a new **AI Experience** settings screen that lets users choose how AI features (Iris, AI-powered feedback) process their data. The choice is persisted to the server and reflected app-wide.

Users can pick between three options:
- **Cloud AI** (recommended) – state-of-the-art cloud LLMs, GDPR-compliant processing on Azure
- **On-premise** (experimental) – open-source LLMs running only in university datacenters
- **No AI** – Artemis without any AI assistance

## Changes

- **`Account` model**: adds `selectedLLMUsage` (`AiSelectionDecision`) and `selectedLLMUsageTimestamp`. New `AiSelectionDecision` enum (`NO_AI` / `LOCAL_AI` / `CLOUD_AI`) mirrors the server, with an `isAIEnabled` helper.
- **`AccountService`**: new `updateLLMSelection(_:)` that `PUT`s to `api/account/users/select-llm-usage` and refreshes the cached account so the new choice is reflected everywhere (e.g. the Iris gate). Stub implementation added.
- **`AiExperienceSettingsViewModel`**: loads the current selection from the server and persists changes.
- **`AiExperienceSettingsView`**: SwiftUI form listing the three options with icons, badges, and feature breakdowns, plus a "Last changed" timestamp and a "Learn more" link that opens in an in-app `SFSafariViewController` (avoids universal-link interception on device).
- **`AccountNavigationBarMenuView`**: new "AI Experience" menu entry presenting the settings screen as a sheet.
- Adds the corresponding English localization keys.


https://github.com/user-attachments/assets/1b37b85c-3927-4d44-ad25-12b50b815b5e